### PR TITLE
ci: add ci ruff workflow

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,8 @@
+name: ruff-ci
+on: [ pull_request ]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,7 @@ postgresql = [
 ]
 dev = [
     "pytest>=7.0.0",
-    "black>=23.0.0",
-    "isort>=5.0.0",
+    "ruff>=0.1.0",
     "mypy>=1.0.0",
     "pre-commit>=3.0.0",
 ]
@@ -66,13 +65,17 @@ auto-tune-vllm = "auto_tune_vllm.cli:main"
 where = ["."]
 include = ["auto_tune_vllm*"]
 
-[tool.black]
+[tool.ruff]
 line-length = 88
-target-version = ['py310']
+target-version = "py310"
 
-[tool.isort]
-profile = "black"
-line_length = 88
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+ignore = []
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
# Summary

Add ruff github CI on every push and pull request (ruff is pretty light weight). @thameem-abbas @aas008 we will want to make the decision whether we auto-reject all PRs that fail this or not.

# Notable

- Add github workflow to run ruff
- Add ruff as apart of the `pyproject.toml` file for dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced automated Ruff linting on pull requests.
  * Standardized code formatting and linting with Ruff across the project.
  * Removed previous formatting/linting tools to reduce duplication and simplify tooling.
  * Updated configuration (e.g., line length, target Python version) to align with Ruff while preserving existing type-checking settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->