### PR TITLE
fix: baseline trial counter and duplicate check bugs

### DIFF
--- a/auto_tune_vllm/core/study_controller.py
+++ b/auto_tune_vllm/core/study_controller.py
@@ -735,10 +735,12 @@ class StudyController:
             True if these parameters match a failed trial, False otherwise
         """
         # Get failed trials (with caching for better performance)
+        # Exclude baseline trials from duplicate check
         failed_trials = [
             trial
             for trial in self.study.trials
             if trial.state in (TrialState.FAIL, TrialState.PRUNED)
+            and not trial.user_attrs.get("is_baseline", False)
         ]
 
         for past_trial in failed_trials:
@@ -1173,6 +1175,8 @@ class StudyController:
                                 values=trial_result.objective_values,
                                 state=TrialState.COMPLETE,
                             )
+                            # Count baseline trial as completed
+                            self.completed_trials += 1
                         else:
                             logger.error(
                                 f"❌ Baseline trial failed: "
@@ -1184,6 +1188,8 @@ class StudyController:
                                 values=None,
                                 state=TrialState.FAIL,
                             )
+                            # Count baseline trial as completed (even if failed)
+                            self.completed_trials += 1
 
                         # Clean up trial object cache
                         if trial.number in self.trial_objects:
@@ -1206,6 +1212,8 @@ class StudyController:
                         values=None,
                         state=TrialState.FAIL,
                     )
+                    # Count baseline trial as completed (even if timed out)
+                    self.completed_trials += 1
                     # Clean up trial object cache
                     if trial.number in self.trial_objects:
                         del self.trial_objects[trial.number]
@@ -1221,6 +1229,8 @@ class StudyController:
                     values=None,
                     state=TrialState.FAIL,
                 )
+                # Count baseline trial as completed (even if excepted)
+                self.completed_trials += 1
                 # Clean up trial object cache
                 if trial.number in self.trial_objects:
                     del self.trial_objects[trial.number]


### PR DESCRIPTION
Fixes two critical bugs in baseline trial integration (PR #111):

1. **Baseline trials not counted in completed_trials**
   - Baseline trials were creating Optuna trial objects but not incrementing self.completed_trials counter
   - This caused the optimization loop to think no trials had run
   - Result: System would try to run n_trials MORE trials after baseline
   - If trials failed quickly, created thousands of phantom failed trials
   - Fix: Increment self.completed_trials after each baseline completion (success, failure, timeout, or exception)

2. **Baseline trials blocking optimization trials in duplicate check**
   - Failed baseline trials (with empty params {}) were being included in duplicate parameter detection
   - Optimization trials with empty params were incorrectly flagged as duplicates of the failed baseline
   - Result: Optimization trials skipped with "duplicate parameters" warning
   - Fix: Exclude baseline trials from duplicate check by checking is_baseline user attribute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of trial completion tracking for baseline experiments across all outcome states (success, failure, timeout, exception).
  * Enhanced baseline trial handling to ensure proper reporting to the optimization framework.
  * Fixed cache cleanup for baseline trial data to prevent memory accumulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->