### PR TITLE
feat: add support for boolean False values with --no- prefix

### DIFF
--- a/auto_tune_vllm/core/trial.py
+++ b/auto_tune_vllm/core/trial.py
@@ -89,6 +89,10 @@ class TrialConfig:
             if isinstance(value, bool):
                 if value:
                     args.append(f"--{cli_param}")
+                else:
+                    # When False, add --no- prefix
+                    # Evidence from vLLM help: --enable-chunked-prefill, --no-enable-chunked-prefill
+                    args.append(f"--no-{cli_param}")
             else:
                 args.extend([f"--{cli_param}", str(value)])
 

--- a/auto_tune_vllm/core/trial.py
+++ b/auto_tune_vllm/core/trial.py
@@ -90,8 +90,7 @@ class TrialConfig:
                 if value:
                     args.append(f"--{cli_param}")
                 else:
-                    # When False, add --no- prefix
-                    # Evidence from vLLM help: --enable-chunked-prefill, --no-enable-chunked-prefill
+                    # When False, add --no- prefix for vLLM
                     args.append(f"--no-{cli_param}")
             else:
                 args.extend([f"--{cli_param}", str(value)])

--- a/auto_tune_vllm/execution/trial_controller.py
+++ b/auto_tune_vllm/execution/trial_controller.py
@@ -853,7 +853,6 @@ class BaseTrialController(TrialController):
             str(port),
             "--host",
             "0.0.0.0",
-            "--no-enable-prefix-caching",
         ]
 
         # Add trial-specific parameters


### PR DESCRIPTION
- Update TrialConfig to handle boolean False values by adding --no- prefix to CLI parameters (e.g., --no-enable-chunked-prefill)
- Remove hardcoded --no-enable-prefix-caching from trial_controller as it's now handled by the boolean parameter logic
- Fixes issue where boolean False values were not properly passed to vLLM CLI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit support for disabling boolean CLI options via --no-<option> flags, matching vLLM conventions.

* **Chores**
  * Adjusted vLLM server startup configuration by removing the prefix-caching toggle from startup arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->