### PR TITLE
Feature/rename max concurrent to max concurrent trials

### DIFF
--- a/auto_tune_vllm/core/config.py
+++ b/auto_tune_vllm/core/config.py
@@ -69,8 +69,8 @@ class OptimizationConfig:
     objective: Union[str, List[str]] = None  # Old format: "maximize", "minimize", list
     sampler: str = "tpe"  # "tpe", "random", "gp", "botorch", "nsga2", "grid"
     n_trials: int = 100
-    n_startup_trials: int = 10  # Number of random startup trials 
-    max_concurrent: Optional[int] = (
+    n_startup_trials: int = 10  # Number of random startup trials
+    max_concurrent_trials: Optional[int] = (
         None  # Maximum concurrent trials (required for resource management)
     )
 

--- a/auto_tune_vllm/core/study_controller.py
+++ b/auto_tune_vllm/core/study_controller.py
@@ -460,7 +460,7 @@ class StudyController:
     def run_optimization(
         self,
         n_trials: int | None = None,
-        max_concurrent: int | None = None,
+        max_concurrent_trials: int | None = None,
         poll_interval: float = 5.0,
     ) -> optuna.Study:
         """
@@ -468,7 +468,7 @@ class StudyController:
 
         Args:
             n_trials: Number of trials to run (overrides config)
-            max_concurrent: Maximum concurrent trials (None = unlimited)
+            max_concurrent_trials: Maximum concurrent trials (None = unlimited)
             poll_interval: How often to poll for completed trials (seconds)
 
         Returns:
@@ -477,20 +477,20 @@ class StudyController:
         total_trials = n_trials or self.config.optimization.n_trials
 
         # Require explicit, positive concurrency specification
-        if max_concurrent is None:
+        if max_concurrent_trials is None:
             msg = (
-                "❌ --max-concurrent is required to prevent GPU memory conflicts!\n\n"
+                "❌ --max-concurrent-trials is required to prevent GPU memory conflicts!\n\n"
                 "Add to your YAML config:\n"
                 "  optimization:\n"
-                "    max_concurrent: 2  # Match your GPU count\n\n"
-                "Or use CLI: --max-concurrent 2"
+                "    max_concurrent_trials: 2  # Match your GPU count\n\n"
+                "Or use CLI: --max-concurrent-trials 2"
             )
             raise ValueError(msg)
-        if max_concurrent < 1:
-            raise ValueError("--max-concurrent must be >= 1")
+        if max_concurrent_trials < 1:
+            raise ValueError("--max-concurrent-trials must be >= 1")
 
         max_concurrent_str = (
-            max_concurrent if max_concurrent != float("inf") else "unlimited"
+            max_concurrent_trials if max_concurrent_trials != float("inf") else "unlimited"
         )
         logger.info(
             f"Starting optimization: {total_trials} trials, "
@@ -508,7 +508,7 @@ class StudyController:
                     remaining_trials=total_trials
                     - self.completed_trials
                     - len(self.active_trials),
-                    max_concurrent=max_concurrent,
+                    max_concurrent_trials=max_concurrent_trials,
                 )
 
                 # Poll for completed trials
@@ -610,9 +610,9 @@ class StudyController:
                 self.backend.shutdown()
                 logger.info("Backend shutdown complete.")
 
-    def _submit_available_trials(self, remaining_trials: int, max_concurrent: float):
+    def _submit_available_trials(self, remaining_trials: int, max_concurrent_trials: float):
         """Submit new trials up to limits."""
-        while remaining_trials > 0 and len(self.active_trials) < max_concurrent:
+        while remaining_trials > 0 and len(self.active_trials) < max_concurrent_trials:
             trial = self.study.ask()
 
             # Check if these exact parameters have already been tried and failed

--- a/auto_tune_vllm/core/study_controller.py
+++ b/auto_tune_vllm/core/study_controller.py
@@ -479,7 +479,8 @@ class StudyController:
         # Require explicit, positive concurrency specification
         if max_concurrent_trials is None:
             msg = (
-                "❌ --max-concurrent-trials is required to prevent GPU memory conflicts!\n\n"
+                "❌ --max-concurrent-trials is required to prevent "
+                "GPU memory conflicts!\n\n"
                 "Add to your YAML config:\n"
                 "  optimization:\n"
                 "    max_concurrent_trials: 2  # Match your GPU count\n\n"
@@ -490,7 +491,9 @@ class StudyController:
             raise ValueError("--max-concurrent-trials must be >= 1")
 
         max_concurrent_str = (
-            max_concurrent_trials if max_concurrent_trials != float("inf") else "unlimited"
+            max_concurrent_trials
+            if max_concurrent_trials != float("inf")
+            else "unlimited"
         )
         logger.info(
             f"Starting optimization: {total_trials} trials, "
@@ -610,9 +613,14 @@ class StudyController:
                 self.backend.shutdown()
                 logger.info("Backend shutdown complete.")
 
-    def _submit_available_trials(self, remaining_trials: int, max_concurrent_trials: float):
+    def _submit_available_trials(
+        self, remaining_trials: int, max_concurrent_trials: float
+    ):
         """Submit new trials up to limits."""
-        while remaining_trials > 0 and len(self.active_trials) < max_concurrent_trials:
+        while (
+            remaining_trials > 0
+            and len(self.active_trials) < max_concurrent_trials
+        ):
             trial = self.study.ask()
 
             # Check if these exact parameters have already been tried and failed

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -223,7 +223,7 @@ You can now explore optimization history, parameter importance, and parallel coo
     ray stop --force
     ray start --head --dashboard-host=0.0.0.0
     ```
-- **Important**: Add `--max-concurrent <count>` or set `max_concurrent: <count>` in your YAML config.
+- **Important**: Add `--max-concurrent-trials <count>` or set `max_concurrent_trials: <count>` in your YAML config.
 
 ### Next Steps
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CLI flag renamed from --max-concurrent to --max-concurrent-trials
  * Configuration key renamed from max_concurrent to max_concurrent_trials
  * Optimization startup trials default remains 10
  * Progress and error messages updated to reference the new flag/key

* **Documentation**
  * Quick start and CLI guidance updated to use the new flag and config key
<!-- end of auto-generated comment: release notes by coderabbit.ai -->