### PR TITLE
Fix cleanup race condition and add TTFT/TPOT dashboard metrics

### DIFF
--- a/auto_tune_vllm/benchmarks/config.py
+++ b/auto_tune_vllm/benchmarks/config.py
@@ -29,6 +29,10 @@ class BenchmarkConfig:
     output_tokens_min: Optional[int] = None
     output_tokens_max: Optional[int] = None
 
+    # GuideLLM request type and formatter kwargs - only added to command when set
+    request_type: Optional[str] = None  # e.g. "text_completions", "chat_completions"
+    request_formatter_kwargs: Optional[str] = None  # JSON string, e.g. '{"extras":{"include_reasoning":true}}'
+
     # Set in benchmark section of study config
     # Logging level for GuideLLM
     logging_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"

--- a/auto_tune_vllm/benchmarks/providers.py
+++ b/auto_tune_vllm/benchmarks/providers.py
@@ -337,7 +337,11 @@ class GuideLLMBenchmark(BenchmarkProvider):
             "--output-path",
             results_file,
             "--processor-args",
-            '{"trust-remote-code":"true"}'
+            '{"trust-remote-code":"true"}',
+            "--request-formatter-kwargs",
+            '{"extras":{"include_reasoning":true}}',
+            "--request-type",
+            "text_completions"
         ]
 
         # Add dataset or synthetic data configuration

--- a/auto_tune_vllm/benchmarks/providers.py
+++ b/auto_tune_vllm/benchmarks/providers.py
@@ -174,15 +174,15 @@ class GuideLLMBenchmark(BenchmarkProvider):
         "output_tokens_per_second": "total",
         "requests_per_second": "total",
         "tokens_per_second": "total",
-        # Quality metrics - use 'successful' for performance characteristics
-        "request_latency": "successful",
-        "time_to_first_token_ms": "successful",
-        "inter_token_latency_ms": "successful",
-        "time_per_output_token_ms": "successful",
-        # Count metrics - use 'successful'
-        "output_token_count": "successful",
-        "prompt_token_count": "successful",
-        "request_concurrency": "successful",
+        # Quality metrics - use 'total' for all requests
+        "request_latency": "total",
+        "time_to_first_token_ms": "total",
+        "inter_token_latency_ms": "total",
+        "time_per_output_token_ms": "total",
+        # Count metrics - use 'total'
+        "output_token_count": "total",
+        "prompt_token_count": "total",
+        "request_concurrency": "total",
     }
 
     def start_benchmark(
@@ -338,11 +338,13 @@ class GuideLLMBenchmark(BenchmarkProvider):
             results_file,
             "--processor-args",
             '{"trust-remote-code":"true"}',
-            "--request-formatter-kwargs",
-            '{"extras":{"include_reasoning":true}}',
-            "--request-type",
-            "text_completions"
         ]
+
+        # Add request-type and request-formatter-kwargs only when configured
+        if config.request_formatter_kwargs is not None:
+            cmd.extend(["--request-formatter-kwargs", config.request_formatter_kwargs])
+        if config.request_type is not None:
+            cmd.extend(["--request-type", config.request_type])
 
         # Add dataset or synthetic data configuration
         if config.use_synthetic_data:

--- a/auto_tune_vllm/core/study_controller.py
+++ b/auto_tune_vllm/core/study_controller.py
@@ -929,6 +929,21 @@ class StudyController:
                 f"status={result.execution_info.trial_status}"
             )
 
+        # Store TTFT and TPOT mean as Optuna user attributes for dashboard columns
+        if result.success and result.detailed_metrics:
+            for attr_name, metric_key in {
+                "ttft_mean_ms": "time_to_first_token_ms_mean",
+                "tpot_mean_ms": "inter_token_latency_ms_mean",
+            }.items():
+                value = result.detailed_metrics.get(metric_key)
+                if value is not None:
+                    trial.set_user_attr(attr_name, round(value, 3))
+            logger.info(
+                f"Stored TTFT/TPOT for trial {trial_number}: "
+                f"ttft_mean={result.detailed_metrics.get('time_to_first_token_ms_mean')}, "
+                f"tpot_mean={result.detailed_metrics.get('inter_token_latency_ms_mean')}"
+            )
+
     def get_best_baseline_result(self) -> list[float] | None:
         """Get the best baseline result for comparison."""
         if not self.baseline_results:

--- a/auto_tune_vllm/core/study_controller.py
+++ b/auto_tune_vllm/core/study_controller.py
@@ -929,11 +929,13 @@ class StudyController:
                 f"status={result.execution_info.trial_status}"
             )
 
-        # Store TTFT and TPOT mean as Optuna user attributes for dashboard columns
+        # Store TTFT and TPOT metrics as Optuna user attributes for dashboard
         if result.success and result.detailed_metrics:
             for attr_name, metric_key in {
                 "ttft_mean_ms": "time_to_first_token_ms_mean",
+                "ttft_p95_ms": "time_to_first_token_ms_p95",
                 "tpot_mean_ms": "inter_token_latency_ms_mean",
+                "tpot_p95_ms": "inter_token_latency_ms_p95",
             }.items():
                 value = result.detailed_metrics.get(metric_key)
                 if value is not None:
@@ -941,7 +943,9 @@ class StudyController:
             logger.info(
                 f"Stored TTFT/TPOT for trial {trial_number}: "
                 f"ttft_mean={result.detailed_metrics.get('time_to_first_token_ms_mean')}, "
-                f"tpot_mean={result.detailed_metrics.get('inter_token_latency_ms_mean')}"
+                f"ttft_p95={result.detailed_metrics.get('time_to_first_token_ms_p95')}, "
+                f"tpot_mean={result.detailed_metrics.get('inter_token_latency_ms_mean')}, "
+                f"tpot_p95={result.detailed_metrics.get('inter_token_latency_ms_p95')}"
             )
 
     def get_best_baseline_result(self) -> list[float] | None:

--- a/auto_tune_vllm/execution/trial_controller.py
+++ b/auto_tune_vllm/execution/trial_controller.py
@@ -71,6 +71,7 @@ class BaseTrialController(TrialController):
         self.benchmark_provider: Optional[BenchmarkProvider] = None
         self._environment_validated = False
         self.trial_loggers = {}  # Dict to hold trial-specific loggers
+        self._cleanup_done = False
         self._health_monitor_thread = None
         self._health_monitor_stop = False
         self._health_monitor_stop_event = None
@@ -245,7 +246,7 @@ class BaseTrialController(TrialController):
         """Flush any buffered logs for the trial to ensure all records are written."""
         try:
             # Flush trial-specific loggers if we have them
-            for component_logger in self.trial_loggers.values():
+            for component_logger in getattr(self, 'trial_loggers', {}).values():
                 for handler in component_logger.handlers:
                     try:
                         handler.flush()
@@ -1168,6 +1169,10 @@ class BaseTrialController(TrialController):
 
     def cleanup_resources(self):
         """Clean up vLLM server process and health monitoring."""
+        if getattr(self, '_cleanup_done', False):
+            return
+        self._cleanup_done = True
+
         # Use trial-specific logger if available, otherwise fall back to module logger
         controller_logger = self._get_trial_logger("controller")
 
@@ -1295,7 +1300,7 @@ class BaseTrialController(TrialController):
 
         # Flush all trial logs to ensure cleanup messages are written
         controller_logger.info("Trial Controller: Cleanup complete, flushing logs...")
-        for component_logger in self.trial_loggers.values():
+        for component_logger in getattr(self, 'trial_loggers', {}).values():
             for handler in component_logger.handlers:
                 try:
                     handler.flush()


### PR DESCRIPTION
- Fix double-cleanup race condition in trial_controller.py that caused studies to hang when __del__ and finally block both call cleanup_resources(). Added idempotency guard and defensive getattr for trial_loggers to handle actors where __init__ never completed.
- Store TTFT and TPOT mean as Optuna user attributes in study_controller.py so they appear as columns in the Optuna dashboard.
- Add --request-type text_completions and --request-formatter-kwargs to GuideLLM command builder in providers.py to support models using the completions API endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Benchmarks can pass request_type and request_formatter_kwargs to the command builder.

* **New Features**
  * Automatically capture and store TTFT/TPOT mean and 95th‑percentile metrics from successful trials (rounded).

* **Bug Fixes**
  * Prevent redundant cleanup runs and avoid logger attribute errors.

* **Bug Fixes**
  * Adjusted metric categorization: certain latency and token-count metrics now reported under "total" instead of "successful".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->