### PR TITLE
[FEAT] make ray optional and enable local backend execution (without ray)

### DIFF
--- a/auto_tune_vllm/cli/main.py
+++ b/auto_tune_vllm/cli/main.py
@@ -6,7 +6,6 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-import ray
 import typer
 from rich.console import Console
 from rich.logging import RichHandler
@@ -16,7 +15,7 @@ from rich.table import Table
 from ..core.config import StudyConfig
 from ..core.storage.postgres_utils import clear_study_data, verify_database_connection
 from ..core.study_controller import StudyController
-from ..execution.backends import RayExecutionBackend
+from ..execution.backends import LocalExecutionBackend, RayExecutionBackend
 from ..logging.manager import CentralizedLogger, LogStreamer
 
 # Setup rich console and app
@@ -116,7 +115,7 @@ def optimize_command(
         "ray",
         "--backend",
         "-b",
-        help="Execution backend: 'ray' (only supported option)",
+        help="Execution backend: 'ray' or 'local' (single worker, no Ray)",
     ),
     n_trials: Optional[int] = typer.Option(
         None, "--trials", "-n", help="Number of trials (overrides config)"
@@ -150,27 +149,32 @@ def optimize_command(
     """Run optimization study."""
     setup_logging(verbose)
 
-    # Validate Python environment options (exactly one should be specified)
+    # Validate Python environment options for Ray backend (exactly one required)
     python_env_options = [python_executable, venv_path, conda_env]
     specified_options = [opt for opt in python_env_options if opt is not None]
 
-    if len(specified_options) == 0:
-        console.print(
-            "[bold red]"
-            "Error: At least one Python environment option must be specified"
-            "[/bold red]"
-        )
-        console.print("Choose one of: --python-executable, --venv-path, or --conda-env")
-        raise typer.Exit(1)
-
-    if len(specified_options) > 1:
-        console.print(
-            "[bold red]"
-            "Error: Only one Python environment option can be specified at a time"
-            "[/bold red]"
-        )
-        console.print("Choose one of: --python-executable, --venv-path, or --conda-env")
-        raise typer.Exit(1)
+    if backend.lower() == "ray":
+        if len(specified_options) == 0:
+            console.print(
+                "[bold red]"
+                "Error: At least one Python environment option must be specified "
+                "for Ray backend"
+                "[/bold red]"
+            )
+            console.print(
+                "Choose one of: --python-executable, --venv-path, or --conda-env"
+            )
+            raise typer.Exit(1)
+        if len(specified_options) > 1:
+            console.print(
+                "[bold red]"
+                "Error: Only one Python environment option can be specified at a time"
+                "[/bold red]"
+            )
+            console.print(
+                "Choose one of: --python-executable, --venv-path, or --conda-env"
+            )
+            raise typer.Exit(1)
 
     console.print("[bold green]Starting auto-tune-vllm optimization[/bold green]")
     console.print(f"Configuration: {config}")
@@ -187,6 +191,9 @@ def optimize_command(
         console.print(
             "[yellow]No Python environment specified, using auto-detection[/yellow]"
         )
+
+    if backend.lower() == "local":
+        console.print("[blue]Using local execution (single worker, no Ray)[/blue]")
 
     try:
         # Load configuration
@@ -222,40 +229,35 @@ def optimize_command(
                     "Ray auto-start disabled - requires existing cluster"
                     "[/yellow]"
                 )
+        elif backend.lower() == "local":
+            max_local = (
+                max_concurrent_trials
+                or study_config.optimization.max_concurrent_trials
+                or 1
+            )
+            execution_backend = LocalExecutionBackend(max_concurrent=max_local)
         else:
-            console.print(
-                "[bold red]"
-                "Error: Local execution backend is not supported in this version."
-                "[/bold red]"
-            )
-            console.print(
-                "[bold red]Only Ray distributed execution is available.[/bold red]"
-            )
-            console.print(
-                "[blue]Use --backend ray (default) or set up a Ray cluster.[/blue]"
-            )
-            console.print(
-                "[blue]See docs/ray_cluster_setup.md for Ray setup instructions.[/blue]"
-            )
+            console.print(f"[bold red]Error: Unknown backend '{backend}'.[/bold red]")
+            console.print("[blue]Use --backend ray or --backend local.[/blue]")
             raise typer.Exit(1)
 
         # Run optimization
-        # Use CLI value or fall back to YAML config
+        # Use CLI value or fall back to YAML config (default 1 for local backend)
         final_max_concurrent_trials = (
             max_concurrent_trials or study_config.optimization.max_concurrent_trials
         )
         if final_max_concurrent_trials is None:
-            console.print(
-                "[bold red]"
-                "❌ --max-concurrent-trials is required "
-                "(or set optimization.max_concurrent_trials in the config)"
-                "[/bold red]"
-            )
-            console.print(
-                "YAML:\n  optimization:\n"
-                "    max_concurrent_trials: 2"
-            )
-            raise typer.Exit(1)
+            if backend.lower() == "local":
+                final_max_concurrent_trials = 1
+            else:
+                console.print(
+                    "[bold red]"
+                    "❌ --max-concurrent-trials is required "
+                    "(or set optimization.max_concurrent_trials in the config)"
+                    "[/bold red]"
+                )
+                console.print("YAML:\n  optimization:\n    max_concurrent_trials: 2")
+                raise typer.Exit(1)
         if final_max_concurrent_trials < 1:
             console.print(
                 "[bold red]❌ --max-concurrent-trials must be >= 1[/bold red]"
@@ -405,8 +407,7 @@ def run_optimization_sync(
             # User interrupted with Ctrl+C
             progress.update(task, description="⚠️  Optimization interrupted by user")
             logger.warning(
-                "Keyboard interrupt received (Ctrl+C). "
-                "Initiating graceful shutdown..."
+                "Keyboard interrupt received (Ctrl+C). Initiating graceful shutdown..."
             )
             console.print(
                 "\n[yellow]⚠️  Interrupt signal received. "
@@ -815,7 +816,7 @@ def resume_command(
         "ray",
         "--backend",
         "-b",
-        help="Execution backend: 'ray' (only supported option)",
+        help="Execution backend: 'ray' or 'local' (single worker, no Ray)",
     ),
     n_trials: Optional[int] = typer.Option(
         None, "--trials", "-n", help="Number of additional trials to run"
@@ -851,27 +852,32 @@ def resume_command(
     """Resume an existing optimization study. Fails if the study doesn't exist."""
     setup_logging(verbose)
 
-    # Validate Python environment options (exactly one should be specified)
+    # Validate Python environment options for Ray backend (exactly one required)
     python_env_options = [python_executable, venv_path, conda_env]
     specified_options = [opt for opt in python_env_options if opt is not None]
 
-    if len(specified_options) == 0:
-        console.print(
-            "[bold red]"
-            "Error: At least one Python environment option must be specified"
-            "[/bold red]"
-        )
-        console.print("Choose one of: --python-executable, --venv-path, or --conda-env")
-        raise typer.Exit(1)
-
-    if len(specified_options) > 1:
-        console.print(
-            "[bold red]"
-            "Error: Only one Python environment option can be specified at a time"
-            "[/bold red]"
-        )
-        console.print("Choose one of: --python-executable, --venv-path, or --conda-env")
-        raise typer.Exit(1)
+    if backend.lower() == "ray":
+        if len(specified_options) == 0:
+            console.print(
+                "[bold red]"
+                "Error: At least one Python environment option must be specified "
+                "for Ray backend"
+                "[/bold red]"
+            )
+            console.print(
+                "Choose one of: --python-executable, --venv-path, or --conda-env"
+            )
+            raise typer.Exit(1)
+        if len(specified_options) > 1:
+            console.print(
+                "[bold red]"
+                "Error: Only one Python environment option can be specified at a time"
+                "[/bold red]"
+            )
+            console.print(
+                "Choose one of: --python-executable, --venv-path, or --conda-env"
+            )
+            raise typer.Exit(1)
 
     console.print("[bold blue]Resuming auto-tune-vllm study[/bold blue]")
 
@@ -900,49 +906,45 @@ def resume_command(
                     "Ray auto-start disabled - requires existing cluster"
                     "[/yellow]"
                 )
-
+        elif backend.lower() == "local":
+            max_local = (
+                max_concurrent_trials
+                or study_config.optimization.max_concurrent_trials
+                or 1
+            )
+            execution_backend = LocalExecutionBackend(max_concurrent=max_local)
         else:
-            console.print(
-                "[bold red]"
-                "Error: Local execution backend is not supported in this version."
-                "[/bold red]"
-            )
-            console.print(
-                "[bold red]Only Ray distributed execution is available.[/bold red]"
-            )
-            console.print(
-                "[blue]Use --backend ray (default) or set up a Ray cluster.[/blue]"
-            )
-            console.print(
-                "[blue]See docs/ray_cluster_setup.md for Ray setup instructions.[/blue]"
-            )
+            console.print(f"[bold red]Error: Unknown backend '{backend}'.[/bold red]")
+            console.print("[blue]Use --backend ray or --backend local.[/blue]")
             raise typer.Exit(1)
 
         # Resume study
-        # Use CLI value or fall back to YAML config
+        # Use CLI value or fall back to YAML config (default 1 for local backend)
         final_max_concurrent_trials = (
             max_concurrent_trials or study_config.optimization.max_concurrent_trials
         )
         if n_trials or n_total_trials:  # Only required if we will run new trials
             if final_max_concurrent_trials is None:
-                console.print(
-                    "[bold red]"
-                    "❌ --max-concurrent-trials is required to resume "
-                    "with new trials"
-                    "[/bold red]"
-                )
-                console.print(
-                    "Set CLI flag or config: "
-                    "optimization.max_concurrent_trials"
-                )
-                raise typer.Exit(1)
+                if backend.lower() == "local":
+                    final_max_concurrent_trials = 1
+                else:
+                    console.print(
+                        "[bold red]"
+                        "❌ --max-concurrent-trials is required to resume "
+                        "with new trials"
+                        "[/bold red]"
+                    )
+                    console.print(
+                        "Set CLI flag or config: optimization.max_concurrent_trials"
+                    )
+                    raise typer.Exit(1)
             if final_max_concurrent_trials < 1:
                 console.print(
-                    "[bold red]"
-                    "❌ --max-concurrent-trials must be >= 1"
-                    "[/bold red]"
+                    "[bold red]❌ --max-concurrent-trials must be >= 1[/bold red]"
                 )
                 raise typer.Exit(1)
+        if final_max_concurrent_trials is None and backend.lower() == "local":
+            final_max_concurrent_trials = 1
         resume_study_sync(
             execution_backend,
             study_config,
@@ -1245,6 +1247,7 @@ def check_environment_command(
 def _check_ray_cluster_environment():
     """Check environment on all Ray cluster nodes."""
     try:
+        import ray
 
         if not ray.is_initialized():
             console.print("[yellow]Initializing Ray connection...[/yellow]")

--- a/auto_tune_vllm/execution/backends.py
+++ b/auto_tune_vllm/execution/backends.py
@@ -247,14 +247,11 @@ class RayExecutionBackend(ExecutionBackend):
 
     def submit_trial(self, trial_config: TrialConfig) -> JobHandle:
         """Submit trial to Ray cluster."""
-        import ray
-
-        self._ray = ray
         from .trial_controller import RayTrialActor
 
         # Create a lightweight cancellation flag actor (separate from trial actor)
         # This can be called even while the trial actor is busy
-        CancellationFlagActor = ray.remote(_CancellationFlag)
+        CancellationFlagActor = self._ray.remote(_CancellationFlag)
         cancellation_flag_actor = CancellationFlagActor.remote()
 
         # Create Ray actor with resource requirements from trial config
@@ -589,12 +586,30 @@ class LocalExecutionBackend(ExecutionBackend):
         return completed_results, remaining_handles
 
     def cleanup_all_trials(self):
-        """Cleanup all active trials (stub implementation for local backend)."""
-        logger.info("Local backend does not require explicit trial cleanup")
-        # Local backend doesn't need to do anything special here
-        # Individual trial controllers handle their own cleanup when they complete
+        """Force cleanup of all active local trials by cancelling running futures."""
+        if not self.active_futures:
+            logger.debug("No active local trials to cleanup")
+            return
+
+        logger.info(f"Cancelling {len(self.active_futures)} active local trial(s)")
+
+        # Cancel all running futures
+        for job_id, future in list(self.active_futures.items()):
+            try:
+                if not future.done():
+                    future.cancel()
+                    logger.debug(f"Cancelled local trial {job_id}")
+            except Exception as e:
+                logger.warning(f"Failed to cancel local trial {job_id}: {e}")
+
+        # Clear the tracking collection
+        self.active_futures.clear()
+        logger.info("Completed cleanup of all active local trials")
 
     def shutdown(self):
         """Shutdown thread pool executor."""
-        self.executor.shutdown(wait=True)
+        # Cancel any remaining active futures first
+        self.cleanup_all_trials()
+        # Shutdown without waiting for cancelled tasks to finish
+        self.executor.shutdown(wait=False)
         logger.info("Shutdown local execution backend")

--- a/auto_tune_vllm/execution/backends.py
+++ b/auto_tune_vllm/execution/backends.py
@@ -13,17 +13,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-import ray
-
 from ..core.trial import TrialConfig, TrialResult
 
 logger = logging.getLogger(__name__)
 
 
-# Simple Ray actor to hold cancellation state that can be modified externally
-
-@ray.remote
-class CancellationFlag:
+# Lightweight actor class for Ray cancellation state (wrapped with ray.remote
+# only when RayExecutionBackend is used, so local backend works without Ray)
+class _CancellationFlag:
     """Lightweight Ray actor to hold mutable cancellation state."""
 
     def __init__(self):
@@ -37,6 +34,7 @@ class CancellationFlag:
     def is_cancelled(self):
         """Check if cancellation was requested."""
         return self.cancelled
+
 
 @dataclass
 class JobHandle:
@@ -80,7 +78,7 @@ class ExecutionBackend(ABC):
 
 class RayExecutionBackend(ExecutionBackend):
     """Ray-based distributed execution backend."""
-    
+
     # Cleanup timeouts (in seconds)
     CANCELLATION_FLAG_TIMEOUT = 2
     CANCELLATION_DETECTION_WAIT = 5
@@ -111,6 +109,15 @@ class RayExecutionBackend(ExecutionBackend):
         self.venv_path = venv_path
         self.conda_env = conda_env
 
+        try:
+            import ray
+        except ImportError as e:
+            msg = (
+                "Ray is required for the Ray execution backend. "
+                "Install with: pip install 'auto-tune-vllm[ray]'"
+            )
+            raise ImportError(msg) from e
+        self._ray = ray
         self._ensure_ray_initialized()
 
     def _build_runtime_env(self) -> Dict:
@@ -173,6 +180,7 @@ class RayExecutionBackend(ExecutionBackend):
 
     def _ensure_ray_initialized(self):
         """Initialize Ray if not already initialized."""
+        ray = self._ray
         try:
             if not ray.is_initialized():
                 try:
@@ -227,7 +235,7 @@ class RayExecutionBackend(ExecutionBackend):
             time.sleep(3)
 
             # Connect to the newly started Ray head using auto-discovery
-            ray.init(address="auto", ignore_reinit_error=True)
+            self._ray.init(address="auto", ignore_reinit_error=True)
             self._started_ray_head = True
 
         except subprocess.CalledProcessError as e:
@@ -239,11 +247,15 @@ class RayExecutionBackend(ExecutionBackend):
 
     def submit_trial(self, trial_config: TrialConfig) -> JobHandle:
         """Submit trial to Ray cluster."""
+        import ray
+
+        self._ray = ray
         from .trial_controller import RayTrialActor
 
         # Create a lightweight cancellation flag actor (separate from trial actor)
         # This can be called even while the trial actor is busy
-        cancellation_flag_actor = CancellationFlag.remote()
+        CancellationFlagActor = ray.remote(_CancellationFlag)
+        cancellation_flag_actor = CancellationFlagActor.remote()
 
         # Create Ray actor with resource requirements from trial config
         # Extract num_gpus and num_cpus from trial's resource_requirements
@@ -289,6 +301,7 @@ class RayExecutionBackend(ExecutionBackend):
         self, job_handles: List[JobHandle]
     ) -> Tuple[List[TrialResult], List[JobHandle]]:
         """Poll for completed Ray trials."""
+        ray = self._ray
         if not job_handles:
             return [], []
 
@@ -306,9 +319,7 @@ class RayExecutionBackend(ExecutionBackend):
             return [], job_handles
 
         # Check which trials are ready (non-blocking)
-        ready_refs, _ = ray.wait(
-            active_refs, num_returns=len(active_refs), timeout=0
-        )
+        ready_refs, _ = ray.wait(active_refs, num_returns=len(active_refs), timeout=0)
 
         completed_results = []
         remaining_handles = []
@@ -318,7 +329,7 @@ class RayExecutionBackend(ExecutionBackend):
 
             if ray_ref in ready_refs:
                 try:
-                    result = ray.get(ray_ref)  # Get completed result
+                    result = ray.get(ray_ref)
                     completed_results.append(result)
                     logger.info(f"Completed trial {handle.trial_id}")
                     # Remove from active jobs and actors
@@ -352,12 +363,12 @@ class RayExecutionBackend(ExecutionBackend):
         self, items: dict, method_name: str, description: str
     ) -> list:
         """Execute remote method calls on multiple actors/refs with error handling.
-        
+
         Args:
             items: Dict of job_id -> actor/ref
             method_name: Name of remote method to call
             description: Description for logging
-            
+
         Returns:
             List of (job_id, remote_ref) tuples for successful calls
         """
@@ -376,27 +387,27 @@ class RayExecutionBackend(ExecutionBackend):
 
     def _wait_for_refs(self, futures: list, timeout: float, description: str) -> tuple:
         """Wait for remote refs to complete with timeout.
-        
+
         Returns:
             Tuple of (ready_count, remaining_count)
         """
         if not futures:
             return 0, 0
-        
+
+        ray = self._ray
         try:
             refs_only = [ref for _, ref in futures]
             ready_refs, remaining_refs = ray.wait(
                 refs_only, num_returns=len(refs_only), timeout=timeout
             )
-            
+
             if ready_refs:
                 logger.info(f"✓ {len(ready_refs)} {description} completed")
             if remaining_refs:
                 logger.warning(
-                    f"⚠ {len(remaining_refs)} {description} timed out "
-                    f"after {timeout}s"
+                    f"⚠ {len(remaining_refs)} {description} timed out after {timeout}s"
                 )
-            
+
             return len(ready_refs), len(remaining_refs)
         except Exception as e:
             logger.error(f"Error waiting for {description}: {e}")
@@ -404,7 +415,7 @@ class RayExecutionBackend(ExecutionBackend):
 
     def cleanup_all_trials(self):
         """Force cleanup of all active trials and their vLLM processes.
-        
+
         Cleanup phases:
         1. Set cancellation flags (triggers polling loop detection)
         2. Cancel Ray tasks (sends cancellation signal)
@@ -425,7 +436,7 @@ class RayExecutionBackend(ExecutionBackend):
         self._wait_for_refs(
             cancel_futures, self.CANCELLATION_FLAG_TIMEOUT, "cancellation flags"
         )
-        
+
         # Give polling loops time to detect and terminate benchmarks
         if cancel_futures:
             logger.info(
@@ -433,8 +444,9 @@ class RayExecutionBackend(ExecutionBackend):
                 f"to detect cancellation..."
             )
             time.sleep(self.CANCELLATION_DETECTION_WAIT)
-        
+
         # Phase 2: Cancel Ray tasks
+        ray = self._ray
         logger.info("Phase 2 - Cancelling Ray tasks...")
         cancelled = 0
         for job_id, task_ref in self.active_jobs.items():
@@ -443,36 +455,34 @@ class RayExecutionBackend(ExecutionBackend):
                 cancelled += 1
             except Exception as e:
                 logger.warning(f"Failed to cancel task {job_id}: {e}")
-        
+
         if cancelled:
             logger.info(
                 f"Cancelled {cancelled} Ray task(s), waiting "
                 f"{self.TASK_CANCELLATION_WAIT}s..."
             )
             time.sleep(self.TASK_CANCELLATION_WAIT)
-        
+
         # Phase 3: Call cleanup_resources on actors
         logger.info("Phase 3 - Requesting graceful cleanup from actors...")
         cleanup_futures = self._execute_remote_calls(
             self.active_actors, "cleanup_resources", "Sent cleanup request"
         )
         logger.info(
-            f"Waiting up to {self.GRACEFUL_CLEANUP_TIMEOUT}s "
-            f"for graceful cleanup..."
+            f"Waiting up to {self.GRACEFUL_CLEANUP_TIMEOUT}s for graceful cleanup..."
         )
         self._wait_for_refs(
             cleanup_futures, self.GRACEFUL_CLEANUP_TIMEOUT, "actor cleanups"
         )
-        
+
         # Phase 4: Force kill unresponsive actors
         if self.active_actors:
             logger.warning(
-                f"Force killing {len(self.active_actors)} "
-                f"unresponsive actor(s)..."
+                f"Force killing {len(self.active_actors)} unresponsive actor(s)..."
             )
             for job_id, actor in list(self.active_actors.items()):
                 try:
-                    ray.kill(actor)
+                    self._ray.kill(actor)
                     logger.debug(f"Force killed actor {job_id}")
                 except Exception as e:
                     logger.warning(f"Failed to kill actor {job_id}: {e}")
@@ -485,7 +495,7 @@ class RayExecutionBackend(ExecutionBackend):
 
     def shutdown(self):
         """Shutdown Ray cluster connection."""
-
+        ray = self._ray
         if ray.is_initialized():
             ray.shutdown()
             logger.info("Shutdown Ray cluster connection")

--- a/auto_tune_vllm/execution/trial_controller.py
+++ b/auto_tune_vllm/execution/trial_controller.py
@@ -11,8 +11,10 @@ from abc import ABC, abstractmethod
 from enum import Enum, auto
 from typing import Optional
 
-import ray
-from ray.exceptions import GetTimeoutError
+try:
+    import ray
+except ImportError:
+    ray = None  # type: ignore[assignment]
 
 from ..benchmarks.providers import BenchmarkProvider, GuideLLMBenchmark
 from ..core.trial import ExecutionInfo, TrialConfig, TrialResult
@@ -89,8 +91,10 @@ class BaseTrialController(TrialController):
             "vllm": "vLLM serving framework",
             "guidellm": "GuideLLM benchmarking tool",
             "optuna": "Optuna optimization framework",
-            "ray": "Ray distributed computing",
         }
+        # Ray only required when running as Ray worker (ray is installed and used)
+        if ray is not None:
+            required_packages["ray"] = "Ray distributed computing"
 
         # Only require psycopg2 if using PostgreSQL
         using_postgresql = False
@@ -141,9 +145,9 @@ class BaseTrialController(TrialController):
                 f"Ensure all dependencies are properly installed and available in PATH."
             )
 
-        # Check GPU availability using Ray cluster resources
+        # Check GPU availability using Ray cluster resources (when Ray is in use)
         try:
-            if ray.is_initialized():
+            if ray is not None and ray.is_initialized():
                 cluster_resources = ray.cluster_resources()
                 available_resources = ray.available_resources()
 
@@ -340,15 +344,14 @@ class BaseTrialController(TrialController):
 
                 Works with both Ray actor and local flag.
                 """
-                if cancellation_flag_actor:
+                if cancellation_flag_actor and ray is not None:
                     try:
                         # Use ray.get() with a small timeout to check cancellation
-                        # This ensures the remote call has time to complete
                         is_cancelled = ray.get(
                             cancellation_flag_actor.is_cancelled.remote(), timeout=0.2
                         )
                         return is_cancelled
-                    except (Exception, GetTimeoutError) as _:
+                    except Exception:
                         return False
                 return self._cancellation_requested
 
@@ -590,9 +593,9 @@ class BaseTrialController(TrialController):
             value = os.environ.get(var, "Not set")
             logger.info(f"{var}: {value}")
 
-        # Ray GPU resources and accelerator information
+        # Ray GPU resources and accelerator information (when Ray is in use)
         try:
-            if ray.is_initialized():
+            if ray is not None and ray.is_initialized():
                 cluster_resources = ray.cluster_resources()
                 available_resources = ray.available_resources()
 
@@ -651,7 +654,7 @@ class BaseTrialController(TrialController):
 
         # Ray worker info (if available)
         try:
-            if ray.is_initialized():
+            if ray is not None and ray.is_initialized():
                 runtime_ctx = ray.get_runtime_context()
                 logger.info(f"Ray node ID: {runtime_ctx.get_node_id()}")
                 logger.info(f"Ray worker ID: {runtime_ctx.get_worker_id()}")
@@ -1325,6 +1328,8 @@ class RayWorkerTrialController(BaseTrialController):
 
     def _get_worker_id(self) -> str:
         """Get Ray worker node ID."""
+        if ray is None:
+            return "ray_worker_unknown"
         try:
             return ray.get_runtime_context().get_node_id()
         except Exception:
@@ -1342,7 +1347,7 @@ class RayWorkerTrialController(BaseTrialController):
 
         # Log Ray worker context information
         try:
-            if ray.is_initialized():
+            if ray is not None and ray.is_initialized():
                 runtime_ctx = ray.get_runtime_context()
                 vllm_logger.info(f"Ray worker node: {runtime_ctx.get_node_id()[:8]}")
                 vllm_logger.info(
@@ -1366,17 +1371,24 @@ class RayWorkerTrialController(BaseTrialController):
         return super()._start_vllm_server(trial_config)
 
 
-# Ray remote actor wrapper
-@ray.remote
-class RayTrialActor(RayWorkerTrialController):
-    """Ray remote actor for distributed trial execution."""
+# Ray remote actor wrapper (only defined when Ray is installed)
+if ray is not None:
 
-    def run_trial(
-        self, trial_config: TrialConfig, cancellation_flag_actor=None
-    ) -> TrialResult:
-        """Run trial on Ray worker with optional cancellation flag actor."""
-        return super().run_trial(trial_config, cancellation_flag_actor)
+    @ray.remote
+    class RayTrialActor(RayWorkerTrialController):
+        """Ray remote actor for distributed trial execution."""
 
-    def __del__(self):
-        """Ensure cleanup on actor destruction."""
-        self.cleanup_resources()
+        def run_trial(
+            self, trial_config: TrialConfig, cancellation_flag_actor=None
+        ) -> TrialResult:
+            """Run trial on Ray worker with optional cancellation flag actor."""
+            return super().run_trial(trial_config, cancellation_flag_actor)
+
+        def __del__(self):
+            """Ensure cleanup on actor destruction (only on real instances)."""
+            # Skip when __del__ is run on the actor class proxy at process exit
+            if hasattr(self, "trial_loggers"):
+                self.cleanup_resources()
+
+else:
+    RayTrialActor = None  # type: ignore[misc, assignment]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ requires-python = ">=3.10"
 dependencies = [
     "optuna>=3.0.0",
     "optuna-integration[botorch]>=4.0.0",
-    "ray[default]>=2.0.0",
     "vllm>=0.11.0",
     "guidellm>=0.1.0",
     "pyyaml>=6.0",
@@ -38,6 +37,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+ray = [
+    "ray[default]>=2.0.0",
+]
 postgresql = [
     "psycopg2-binary>=2.9.0",
 ]


### PR DESCRIPTION
### Description
This PR makes Ray an optional dependency and adds support for a local execution backend, allowing users to run auto-tune-vllm on a single machine without a Ray cluster.

### Changes

- Move ray[default] from required to optional (pip install auto-tune-vllm[ray])

- CLI: Add --backend local option alongside existing ray backend

- Python environment options (--python-executable, --venv-path, --conda-env) now only required for Ray backend

- max_concurrent_trials defaults to 1 for local backend (no longer required)

- All Ray imports are now lazy/conditional - the tool works without Ray installed

### Usage

```bash
# Local execution (no Ray needed)
auto-tune-vllm optimize --backend local -c config.yaml

# Ray execution (unchanged)
auto-tune-vllm optimize --backend ray --venv-path ./venv -c config.yaml
```

### Backward Compatibility
Default backend remains ray, existing commands continue to work and users with Ray installed are unaffected.
Clear error message if Ray backend is requested but not installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local execution backend as an alternative to Ray, enabling the tool to run without Ray installed

* **Improvements**
  * Made Ray an optional dependency; install with the `ray` extra for distributed execution
  * Backend-specific validation now tailors configuration requirements based on selected execution backend

<!-- end of auto-generated comment: release notes by coderabbit.ai -->