### PR TITLE
feat: add Claude-driven agentic tuner as an optional extra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ Thumbs.db
 # Default logs and artifacts
 logs/
 optuna_studies/
+agent_reports/
+benchmark_results/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A distributed hyperparameter optimization framework for vLLM serving, built with
 - 🚀 **Distributed Optimization**: Scale across multiple GPUs and nodes using Ray
 - 🎯 **Flexible Backends**: Run locally or on Ray clusters  
 - 📊 **Rich Benchmarking**: Built-in GuideLLM support + custom benchmark providers
+- 🤖 **Agentic Tuner**: Claude-driven pod-per-experiment search (optional `[agent]` extra)
 - 🗄️ **Centralized Storage**: PostgreSQL for trials, metrics, and logs
 - ⚙️ **Easy Configuration**: YAML-based study and parameter configuration
 - 📈 **Multi-Objective**: Support for throughput vs latency trade-offs
@@ -39,13 +40,22 @@ auto-tune-vllm logs --study-id 42 --trial-number 15
 
 # Resume interrupted study
 auto-tune-vllm resume --study-name study_35884
+
+# Claude-driven tuner (keeps the baseline pod read-only)
+pip install -e ".[agent]"
+auto-tune-vllm agent \
+    --vllm-endpoint http://localhost:8000 \
+    --model facebook/opt-125m \
+    --oc-mode --oc-pod <baseline-pod> --oc-namespace <ns> \
+    --pod-template examples/agent/experiment-pod.yaml
 ```
 
 
 ## Documentation
 
 - [Ray Cluster Setup](docs/ray_cluster_setup.md) - **Important for distributed optimization**
-- [Configuration Reference](docs/configuration.md) 
+- [Configuration Reference](docs/configuration.md)
+- [Agentic Tuner](docs/agentic_tuning.md) - Claude-driven pod-per-experiment alternative to Optuna 
 
 ## Requirements
 

--- a/auto_tune_vllm/agent/__init__.py
+++ b/auto_tune_vllm/agent/__init__.py
@@ -1,0 +1,14 @@
+"""Claude-driven vLLM performance tuning agent.
+
+Install optional dependencies with::
+
+    pip install -e ".[agent]"
+
+Run via::
+
+    auto-tune-vllm agent --vllm-endpoint http://localhost:8000 --model <model> ...
+    python -m auto_tune_vllm.agent ...
+"""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/auto_tune_vllm/agent/__main__.py
+++ b/auto_tune_vllm/agent/__main__.py
@@ -1,0 +1,6 @@
+"""Allow running as: python -m auto_tune_vllm.agent"""
+
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/auto_tune_vllm/agent/agentic.py
+++ b/auto_tune_vllm/agent/agentic.py
@@ -1,0 +1,537 @@
+"""
+Agent Loop & vLLM System Prompt
+
+The core agentic loop: assembles messages, calls Claude, dispatches tool calls,
+and iterates until the agent signals completion or hits max iterations.
+
+SOURCE: ai-perf-hackathon/agent/agentic.py (loop reused, prompt replaced)
+"""
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+@dataclass
+class AgentState:
+    """Current state of the agent."""
+
+    iteration: int = 0
+    baseline_results: dict = field(default_factory=dict)
+    current_results: dict = field(default_factory=dict)
+    actions_taken: list = field(default_factory=list)
+    kernel_analysis: dict = field(default_factory=dict)
+    done: bool = False
+    success: bool = False
+    summary: str = ""
+
+
+SYSTEM_PROMPT = """You are an autonomous vLLM performance tuning agent.
+
+GOAL: Benchmark, profile, analyze, and tune a vLLM inference server to maximize
+throughput while maintaining acceptable latency SLOs.
+
+ENVIRONMENT:
+- Use `uv` for all Python project and dependency management (install packages,
+  run scripts, manage virtualenvs). For example: `uv pip install guidellm`,
+  `uv run python script.py`. Do NOT use raw pip or conda for installing packages.
+
+TOOLS AVAILABLE:
+- run_command: Execute shell commands on the vLLM pod/host (runs REMOTELY on pod)
+- read_file: Read files from the vLLM pod/host (runs REMOTELY on pod)
+- write_file: Write files to the vLLM pod/host (runs REMOTELY on pod)
+- run_benchmark: Run GuideLLM benchmark (runs LOCALLY, hits the port-forwarded endpoint)
+- fetch_vllm_logs: Fetch + parse vLLM logs from pod with 120+ regex patterns (runs REMOTELY)
+- read_benchmark_results: Read a GuideLLM JSON file and extract structured metrics (runs LOCALLY)
+- compare_benchmarks: Compare two benchmark JSON files to detect regressions (runs LOCALLY)
+- analyze_trace: Analyze a PyTorch profiler Chrome trace JSON (runs LOCALLY)
+- map_kernel: Map a CUDA kernel name to its source and category (runs LOCALLY)
+- create_vllm_pod: Create an experiment pod with extra vLLM args (returns pod_name + endpoint)
+- delete_vllm_pod: Delete an experiment pod and clean up port-forward
+- done: Signal completion with summary
+
+ARCHITECTURE:
+- The BASELINE pod is running and port-forwarded. It is NEVER modified or restarted.
+- For each tuning experiment, create a NEW pod with create_vllm_pod.
+- run_command/read_file/write_file/fetch_vllm_logs execute INSIDE a pod.
+  Pass pod_name to target an experiment pod; omit to target the baseline pod.
+- run_benchmark runs LOCALLY. Pass endpoint from create_vllm_pod to benchmark
+  an experiment pod; omit endpoint to benchmark the baseline.
+- run_benchmark model is AUTO-FILLED — just specify the profile name (and endpoint if experiment).
+
+TUNING WORKFLOW (follow this order strictly):
+
+0. FIRST, look up the vLLM recipes page for model-specific optimizations:
+   a. Run: run_command with command="curl -s https://recipes.vllm.ai/models.json"
+      This returns a JSON array of all models with recipes. Search for an entry
+      whose "hf_id" matches (or is close to) the model being served.
+   b. If a match is found, fetch the model recipe:
+      run_command with command="curl -s https://recipes.vllm.ai/{hf_id}.json"
+      (e.g. "curl -s https://recipes.vllm.ai/meta-llama/Llama-3.1-8B-Instruct.json")
+   c. The recipe JSON contains:
+      - model.base_args: recommended base vLLM args
+      - variants: precision/quantization options (e.g. fp8, nvfp4) with extra_args
+      - hardware_overrides: hardware-specific args (e.g. for AMD)
+      - features / opt_in_features: optional features to enable
+   d. Use the recipe's recommended args as your FIRST experiment. Then build on
+      top of them with additional tuning.
+   e. If curl fails (no internet on the pod), skip this step and proceed with
+      the known-good practices listed below.
+
+1. Benchmark the BASELINE pod (already running, uses default endpoint):
+   a. Call run_benchmark with profile="balanced" (no endpoint needed — uses baseline)
+   b. Call fetch_vllm_logs (no pod_name — reads baseline pod logs)
+   c. Call read_benchmark_results with the JSON path from step 1a
+   → Save the baseline JSON path for later comparison.
+
+2. For EACH tuning experiment:
+   a. Call create_vllm_pod with vllm_args (e.g. ["--enable-chunked-prefill"])
+      → Returns pod_name and endpoint (e.g. "http://localhost:8001")
+   b. Call run_benchmark with profile="balanced" AND endpoint from step 2a
+   c. Call fetch_vllm_logs with pod_name from step 2a (reads experiment pod logs)
+   d. Call read_benchmark_results with the JSON path from step 2b
+   e. Call compare_benchmarks with baseline JSON (from step 1c) and experiment JSON (from step 2d)
+   f. Call delete_vllm_pod with pod_name from step 2a to clean up
+
+3. NEVER kill processes on the baseline pod. NEVER restart the baseline pod.
+   All tuning is done by creating fresh experiment pods with different args.
+
+4. Call done with all comparison results when finished.
+
+MANDATORY WORKFLOW FOR EACH BENCHMARK CYCLE:
+After EVERY run_benchmark call, you MUST do BOTH of these before making any decisions:
+
+1. CALL fetch_vllm_logs (with pod_name if experiment pod): This parses the vLLM
+   server logs and returns structured data: server config (model, non-default args),
+   engine config (dtype, quantization, TP, chunked prefill, CUDA graphs),
+   memory (KV cache size, model memory), compilation (attention backend,
+   torch.compile time), and warnings/errors.
+
+2. CALL read_benchmark_results with the JSON path from run_benchmark output:
+   This returns structured per-concurrency metrics: success rate, throughput,
+   TTFT, ITL, TPOT with P50/P95/P99 percentiles.
+
+AFTER TUNING, use compare_benchmarks:
+   Pass the baseline JSON path and the post-tuning JSON path to get a side-by-side
+   comparison with regression detection (2% threshold, metric directionality aware).
+
+IF BENCHMARK FAILS (errored requests > 0):
+- Do NOT call done. Do NOT give up.
+- Call fetch_vllm_logs (with pod_name if experiment) to understand WHY requests are failing
+- Common causes: model not loaded, wrong model name, OOM, CUDA error, timeout
+- Try: run_command "curl -s http://localhost:8000/health" (inside pod, use pod_name for experiment)
+- Try: run_command "curl -s http://localhost:8000/v1/models" (inside pod)
+- If an experiment pod is broken, delete it and try different args
+
+KEY METRICS (from GuideLLM output):
+- Output Token Throughput (tokens/sec) — higher = better
+- TTFT - Time to First Token (ms) at P50, P95, P99 — lower = better
+- ITL - Inter-Token Latency (ms) at P50, P95, P99 — lower = better
+- TPOT - Time Per Output Token (ms) at P50, P95, P99 — lower = better
+- Request Success Rate (%) — must be > 0 to be useful
+
+VLLM TUNABLE PARAMETERS (pass these to create_vllm_pod as vllm_args):
+1. --max-num-seqs (1-1024, default 256): Max concurrent sequences per iteration
+2. --max-num-batched-tokens (256-32768, default auto): Max tokens per batch
+3. --gpu-memory-utilization (0.80-0.95, default 0.90): GPU memory for KV cache
+4. --enable-chunked-prefill (bool, default false): Chunk long prefills
+5. --enable-prefix-caching (bool, default false): Cache common prefixes
+6. --max-model-len (int, default auto): Max context length
+7. --enforce-eager (bool, default false): Disable CUDA graphs
+8. --tensor-parallel-size (1-8, default 1): Multi-GPU parallelism
+9. --quantization (null/fp8/awq/gptq): Quantization method
+10. --scheduling-policy (fcfs/priority): Request scheduling
+11. --kv-cache-dtype (auto/fp8): KV cache data type. fp8 halves cache memory.
+12. --cuda-graph-max-capture-size (int, default ~2048): Max batch size for CUDA graphs
+
+KNOWN-GOOD TUNING PRACTICES (apply these early in your experiments):
+- ALWAYS enable prefix caching (--enable-prefix-caching). It reduces redundant
+  computation for repeated prefixes and almost never hurts performance.
+- Increase --max-num-batched-tokens beyond the default. Larger batch sizes
+  improve GPU utilization and throughput. Try 4096, 8192, or 16384.
+- Increase --max-num-seqs to allow more concurrent sequences when batching.
+- Set --kv-cache-dtype fp8 to use FP8 quantization for the KV cache. This
+  halves KV cache memory usage, allowing more sequences or longer contexts,
+  with minimal accuracy impact.
+- Increase --cuda-graph-max-capture-size (default ~2048). Larger values allow
+  CUDA graphs to cover bigger batch sizes, reducing kernel launch overhead.
+  Try 4096 or 8192.
+
+ANALYSIS GUIDELINES:
+- If TTFT is high: prefill is slow → try chunked-prefill or prefix-caching
+- If ITL is high: decode is slow → check batch size, GPU utilization
+- If throughput plateaus: may need more GPU memory for KV cache, or try
+  --kv-cache-dtype fp8 to fit more tokens in cache
+- If OOM errors: reduce gpu-memory-utilization or max-num-seqs, or try
+  --kv-cache-dtype fp8 to reduce cache memory
+- If all requests error: check vLLM health, model loading, port-forwarding
+
+STOPPING CRITERIA:
+- Keep running experiments until you have had 10 CONSECUTIVE experiments with NO
+  improvement over your current best result. Only then call done.
+- Track a running count of consecutive non-improving experiments. Any experiment
+  that improves throughput OR latency (TTFT/ITL/TPOT) by more than 2% resets
+  the counter to zero.
+- Do NOT stop early just because one or two experiments didn't help. Keep exploring
+  different parameter combinations.
+- When you do call done, include ALL experiment results (not just the best one).
+
+REPORTING FORMAT:
+- Format your done summary as structured text with clear sections:
+  BASELINE: <metrics from baseline benchmark>
+  BEST CONFIGURATION: <the args and metrics of the best experiment>
+  ALL EXPERIMENTS: <table of all experiments with args and key metrics>
+  FINDINGS: <what you learned>
+
+RULES:
+- NEVER modify, kill, or restart the baseline pod
+- ALWAYS call fetch_vllm_logs AND read_benchmark_results after each benchmark
+- ONE parameter change at a time (one experiment pod per tuning attempt)
+- ALWAYS delete experiment pods after benchmarking (call delete_vllm_pod)
+- Compare metrics before vs after each change using compare_benchmarks
+- Do NOT call done until you have 10 consecutive non-improving experiments"""
+
+
+class AgenticRunner:
+    """Runs the autonomous vLLM tuning agent loop."""
+
+    def __init__(
+        self,
+        llm_client,
+        tools,
+        max_iterations: int = 100,
+        vllm_endpoint: str = "http://localhost:8000",
+        model_name: str = "",
+        profiles: list = None,
+        enable_cost_optimization: bool = True,
+    ):
+        self.tools = tools
+        self.llm = llm_client
+        self.max_iterations = max_iterations
+        self.vllm_endpoint = vllm_endpoint
+        self.model_name = model_name
+        self.profiles = profiles or [
+            "balanced",
+            "decode_heavy",
+            "prefill_heavy",
+            "long_context",
+        ]
+        self.state = AgentState()
+        self.messages: list = []
+        self.decision_log: list = []
+        self.enable_cost_optimization = enable_cost_optimization
+        self._benchmark_called = False
+        self._nudge_sent = False
+
+    def run(self) -> AgentState:
+        """Run the autonomous agent loop."""
+        print(">> Starting vLLM performance tuning agent...", flush=True)
+
+        # Initialize conversation
+        self.messages = [
+            {
+                "role": "user",
+                "content": f"""You are connected to a vLLM inference server (baseline pod).
+
+Baseline endpoint (port-forwarded): {self.vllm_endpoint}
+Model: {self.model_name}
+Profiles to benchmark: {", ".join(self.profiles)}
+
+CRITICAL RULES:
+- The BASELINE pod is NEVER modified or restarted. It serves as your reference.
+- To test tuning parameters, create EXPERIMENT pods with create_vllm_pod.
+- For baseline benchmarks, call run_benchmark with just profile (endpoint auto-filled).
+- For experiment benchmarks, pass the endpoint returned by create_vllm_pod.
+- NEVER call done after a benchmark failure. Diagnose from vLLM logs instead.
+
+EXACT STEPS (follow this order strictly):
+
+Phase 1 — Baseline:
+1. Call run_command with command="nvidia-smi" (1 tool call)
+2. Call run_command with command="cat /proc/1/cmdline | tr '\\0' ' '" (see vLLM launch args)
+3. Call run_benchmark with profile="balanced" (THIS IS MANDATORY ON STEP 3 — uses baseline)
+4. AFTER benchmark completes, ALWAYS call BOTH:
+   a. fetch_vllm_logs (parses baseline pod's vLLM server config, memory, errors)
+   b. read_benchmark_results with the JSON path from step 3 output
+   → SAVE the baseline JSON path for later compare_benchmarks calls.
+
+Phase 2 — Experiments (repeat for each tuning attempt):
+5. Call create_vllm_pod with vllm_args (e.g. ["--enable-chunked-prefill"])
+   → Note the returned pod_name and endpoint
+6. Call run_benchmark with profile="balanced" AND endpoint from step 5
+7. Call fetch_vllm_logs with pod_name from step 5
+8. Call read_benchmark_results with the JSON path from step 6
+9. Call compare_benchmarks with baseline JSON (step 4b) and experiment JSON (step 8)
+10. Call delete_vllm_pod with pod_name from step 5
+
+Phase 3 — Completion:
+11. After all experiments, call done with a summary of all comparison results.
+
+Steps 4a/4b (and 7/8 for experiments) are MANDATORY after every benchmark.""",
+            }
+        ]
+
+        # Agentic loop
+        while not self.state.done and self.state.iteration < self.max_iterations:
+            self.state.iteration += 1
+            print(
+                f"\n>> Iteration {self.state.iteration}/{self.max_iterations}",
+                flush=True,
+            )
+
+            # Nudge: if we've done 3+ iterations without benchmarking, inject a reminder
+            if (
+                self.state.iteration >= 4
+                and not self._benchmark_called
+                and not self._nudge_sent
+            ):
+                self._nudge_sent = True
+                self.messages.append(
+                    {
+                        "role": "user",
+                        "content": (
+                            "STOP EXPLORING. You have spent enough iterations on system discovery. "
+                            'Call the run_benchmark tool NOW with profile="balanced". '
+                            "Do NOT call run_command again until you have benchmark results. "
+                            "The endpoint and model are auto-filled — just specify the profile."
+                        ),
+                    }
+                )
+                print("   [Nudge injected: forcing benchmark]", flush=True)
+
+            # Budget warning: when approaching iteration cap, force report save
+            remaining = self.max_iterations - self.state.iteration
+            if remaining == 5:
+                self.messages.append(
+                    {
+                        "role": "user",
+                        "content": (
+                            "WARNING: Only 5 iterations remaining. "
+                            "Call done NOW with all findings so far. "
+                            "Include baseline metrics, experiment results, and comparisons."
+                        ),
+                    }
+                )
+                print("   [Budget warning: 5 iterations left]", flush=True)
+
+            # Call LLM with tools
+            response = self._call_llm_with_tools()
+
+            # Process response
+            if response.stop_reason == "tool_use":
+                self._handle_tool_calls(response)
+            elif response.stop_reason == "end_turn":
+                # Agent is thinking, add response and continue
+                self._add_assistant_message(response)
+                self.messages.append(
+                    {
+                        "role": "user",
+                        "content": "Continue. Use tools to explore, benchmark, or apply changes.",
+                    }
+                )
+
+        if not self.state.done:
+            print(
+                ">> Max iterations reached. Extracting results from decision log...",
+                flush=True,
+            )
+            self._extract_results_from_log()
+
+        return self.state
+
+    def _call_llm_with_tools(self):
+        """Call LLM with tool definitions and cost optimizations."""
+        # Build system prompt with caching
+        if self.enable_cost_optimization:
+            system_content = [
+                {
+                    "type": "text",
+                    "text": SYSTEM_PROMPT,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ]
+        else:
+            system_content = SYSTEM_PROMPT
+
+        model = self.llm.model
+
+        response = self.llm.client.messages.create(
+            model=model,
+            max_tokens=4096,
+            system=system_content,
+            tools=self.tools.get_tool_definitions(),
+            messages=self.messages,
+        )
+
+        usage = response.usage
+        self.llm._get_usage(model).add(
+            usage.input_tokens,
+            usage.output_tokens,
+            cache_read_tokens=getattr(usage, "cache_read_input_tokens", 0) or 0,
+            cache_creation_tokens=getattr(usage, "cache_creation_input_tokens", 0) or 0,
+        )
+
+        return response
+
+    def _handle_tool_calls(self, response):
+        """Handle tool calls from LLM response."""
+        self._add_assistant_message(response)
+
+        tool_results = []
+        for block in response.content:
+            if block.type == "tool_use":
+                result = self._execute_tool(block.name, block.input, block.id)
+                tool_results.append(result)
+
+        self.messages.append({"role": "user", "content": tool_results})
+
+    def _execute_tool(self, name: str, inputs: dict, tool_use_id: str) -> dict:
+        """Execute a single tool and return result."""
+        print(f"   Tool: {name}", flush=True)
+
+        # Log decision (output filled in after execution)
+        log_entry = {
+            "iteration": self.state.iteration,
+            "tool": name,
+            "inputs": inputs,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "output": "",
+        }
+        self.decision_log.append(log_entry)
+
+        if name == "run_benchmark":
+            self._benchmark_called = True
+
+        if name == "done":
+            self.state.done = True
+            self.state.success = inputs.get("success", False)
+            self.state.summary = inputs.get("summary", "")
+            output = "Agent signaled completion."
+
+        else:
+            # Dispatch to tools module (returns ToolResult dataclass)
+            result = self.tools.dispatch(name, inputs)
+            output = result.output or ""
+            if result.error:
+                output = f"Error: {result.error}"
+
+            # Track state changes
+            if name == "write_file":
+                self.state.actions_taken.append(
+                    {
+                        "type": "write_file",
+                        "path": inputs.get("path", ""),
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                    }
+                )
+            elif name == "run_benchmark":
+                # Store benchmark results — first successful benchmark per
+                # profile is baseline; subsequent ones update current_results.
+                # Only store if the benchmark actually succeeded (has metrics).
+                profile = inputs.get("profile", "unknown")
+                is_experiment = bool(
+                    inputs.get("endpoint")
+                    and inputs.get("endpoint") != self.vllm_endpoint
+                )
+                has_metrics = result.success and "Tokens/sec" in output
+                if not is_experiment and profile not in self.state.baseline_results:
+                    if has_metrics:
+                        self.state.baseline_results[profile] = output
+                        print(
+                            f"   [Stored baseline for '{profile}': "
+                            f"{len(output)} chars]",
+                            flush=True,
+                        )
+                    # else: don't store failed baseline — let the next
+                    # successful run fill it in
+                elif has_metrics:
+                    self.state.current_results[profile] = output
+                    print(
+                        f"   [Stored {'experiment' if is_experiment else 'current'} "
+                        f"results for '{profile}': {len(output)} chars]",
+                        flush=True,
+                    )
+            elif name == "analyze_trace":
+                try:
+                    self.state.kernel_analysis = json.loads(output)
+                except (json.JSONDecodeError, TypeError):
+                    self.state.kernel_analysis = {"raw": output}
+
+            if name in ("run_command", "read_file"):
+                cmd_preview = inputs.get("command", inputs.get("path", ""))[:60]
+                print(f"      {cmd_preview}", flush=True)
+
+        log_entry["output"] = output[:4000]
+
+        return {
+            "type": "tool_result",
+            "tool_use_id": tool_use_id,
+            "content": output[:8000],  # Truncate long outputs
+        }
+
+    def _add_assistant_message(self, response):
+        """Add assistant response to messages."""
+        content = []
+        for block in response.content:
+            if block.type == "text":
+                content.append({"type": "text", "text": block.text})
+                print(f"   Agent: {block.text[:120]}...", flush=True)
+            elif block.type == "tool_use":
+                content.append(
+                    {
+                        "type": "tool_use",
+                        "id": block.id,
+                        "name": block.name,
+                        "input": block.input,
+                    }
+                )
+
+        self.messages.append({"role": "assistant", "content": content})
+
+    def _extract_results_from_log(self):
+        """Extract benchmark results from decision_log when agent hits max iterations."""
+        benchmark_outputs = []
+        comparison_outputs = []
+        last_agent_text = ""
+
+        for entry in self.decision_log:
+            if entry["tool"] == "run_benchmark" and entry.get("output", ""):
+                benchmark_outputs.append(entry)
+            elif entry["tool"] == "compare_benchmarks" and entry.get("output", ""):
+                comparison_outputs.append(entry)
+            elif entry["tool"] == "read_benchmark_results" and entry.get("output", ""):
+                benchmark_outputs.append(entry)
+
+        for msg in reversed(self.messages):
+            if msg.get("role") == "assistant":
+                content = msg.get("content", [])
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            last_agent_text = block["text"]
+                            break
+                if last_agent_text:
+                    break
+
+        summary_parts = [
+            f"Max iterations reached ({self.state.iteration}/{self.max_iterations})."
+        ]
+        summary_parts.append(f"Benchmarks run: {len(benchmark_outputs)}")
+        summary_parts.append(f"Comparisons run: {len(comparison_outputs)}")
+
+        if comparison_outputs:
+            last_comparison = comparison_outputs[-1]
+            summary_parts.append(
+                f"\nLatest comparison (iteration {last_comparison['iteration']}):"
+            )
+            summary_parts.append(last_comparison["output"][:2000])
+
+        if last_agent_text:
+            summary_parts.append(f"\nAgent's last analysis:\n{last_agent_text[:1000]}")
+
+        self.state.summary = "\n".join(summary_parts)
+        self.state.success = len(benchmark_outputs) > 0
+
+    def get_decision_log(self) -> list:
+        """Get the decision log."""
+        return self.decision_log

--- a/auto_tune_vllm/agent/analysis/__init__.py
+++ b/auto_tune_vllm/agent/analysis/__init__.py
@@ -1,0 +1,56 @@
+"""Analysis helpers used by the agentic tuner.
+
+Extracted from the PSAP analysis MCP tools and converted to sync functions.
+"""
+
+from .cost import (
+    ACCELERATOR_PRICING,
+    calculate_cost,
+    calculate_cpmt,
+    compare_cost_efficiency,
+    filter_by_slo,
+)
+from .kernel_mapper import (
+    KERNEL_MAPPINGS,
+    PYTORCH_STDLIB_OPS,
+    find_kernel_mapping,
+    is_pytorch_stdlib,
+    map_kernel,
+)
+from .regression import detect_regression
+from .trace_analyzer import (
+    CATEGORY_GROUPS,
+    FUNCTIONAL_PIPELINES,
+    analyze_trace,
+    classify_kernel,
+    extract_kernel_stats,
+    get_category_breakdown,
+    get_pipeline_breakdown,
+    get_top_kernels,
+    merge_stats,
+)
+from .vllm_log_parser import parse_vllm_log
+
+__all__ = [
+    "analyze_trace",
+    "extract_kernel_stats",
+    "merge_stats",
+    "get_top_kernels",
+    "get_category_breakdown",
+    "get_pipeline_breakdown",
+    "classify_kernel",
+    "FUNCTIONAL_PIPELINES",
+    "CATEGORY_GROUPS",
+    "map_kernel",
+    "find_kernel_mapping",
+    "is_pytorch_stdlib",
+    "KERNEL_MAPPINGS",
+    "PYTORCH_STDLIB_OPS",
+    "detect_regression",
+    "parse_vllm_log",
+    "calculate_cost",
+    "calculate_cpmt",
+    "filter_by_slo",
+    "compare_cost_efficiency",
+    "ACCELERATOR_PRICING",
+]

--- a/auto_tune_vllm/agent/analysis/cost.py
+++ b/auto_tune_vllm/agent/analysis/cost.py
@@ -1,0 +1,390 @@
+"""
+Cost Efficiency Calculator
+
+Computes Cost Per Million Tokens (CPMT) and other cost-efficiency metrics
+based on benchmark throughput and accelerator pricing.
+
+SOURCE: AI-Analysis-Agent/psap-mcp-server/psap_mcp_server/src/tools/cost_efficiency_tool.py
+
+Converted to sync plain Python functions. No MCP, S3, async, pandas,
+or logger.
+
+Public API:
+    calculate_cost(throughput: float, accelerator: str = "h100") -> dict
+        Main entry point. Returns cost metrics including CPMT.
+
+    calculate_cpmt(throughput_tok_per_sec: float, hourly_cost: float) -> float
+    filter_by_slo(results: list, max_itl_p95_ms: float | None,
+                  max_ttft_p95_ms: float | None) -> list
+    compare_cost_efficiency(baseline_cpmt: float, current_cpmt: float) -> dict
+
+Constants:
+    ACCELERATOR_PRICING
+"""
+
+from typing import Any, Dict, List, Optional
+
+# ===================================================================== #
+#  Accelerator pricing (per hour, USD)                                   #
+# ===================================================================== #
+# Pricing as of October 2025. Full-instance costs for GPU accelerators;
+# per-core pricing for TPUs.
+
+ACCELERATOR_PRICING: Dict[str, Dict[str, Any]] = {
+    "H200": {
+        "hourly_cost": 41.62,
+        "provider": "AWS",
+        "instance": "p6en.48xlarge",
+        "configuration": "8xNVIDIA H200-144GB",
+        "gpus_per_instance": 8,
+        "notes": "Full 8-GPU instance cost regardless of TP",
+    },
+    "MI300X": {
+        "hourly_cost": 48.00,
+        "provider": "Azure",
+        "instance": "ND96isr_MI300X_v5",
+        "configuration": "8xAMD MI300X-192GB",
+        "gpus_per_instance": 8,
+        "notes": "Full 8-GPU instance cost regardless of TP",
+    },
+    "TPU": {
+        "hourly_cost": 2.70,
+        "provider": "GCP",
+        "instance": "TPU Trillium",
+        "configuration": "Per-core pricing",
+        "gpus_per_instance": 1,
+        "notes": "Per-core pricing, multiply by TP count",
+    },
+    "H100": {
+        "hourly_cost": 40.00,
+        "provider": "AWS/Azure",
+        "instance": "p5.48xlarge (approx)",
+        "configuration": "8xNVIDIA H100-80GB",
+        "gpus_per_instance": 8,
+        "notes": "Full 8-GPU instance cost regardless of TP",
+    },
+    "A100": {
+        "hourly_cost": 30.00,
+        "provider": "AWS/Azure/GCP",
+        "instance": "p4de.24xlarge (approx)",
+        "configuration": "8xNVIDIA A100-80GB",
+        "gpus_per_instance": 8,
+        "notes": "Full 8-GPU instance cost regardless of TP",
+    },
+}
+
+
+# ===================================================================== #
+#  Core CPMT formula                                                     #
+# ===================================================================== #
+
+
+def calculate_cpmt(
+    throughput_tok_per_sec: float,
+    hourly_cost: float,
+) -> float:
+    """Compute Cost Per Million Tokens (CPMT).
+
+    Formula::
+
+        CPMT = (time_for_1M_tokens_in_seconds * hourly_cost) / 3600
+
+    Which simplifies to::
+
+        CPMT = (1_000_000 / throughput) * (hourly_cost / 3600)
+
+    Args:
+        throughput_tok_per_sec: Effective throughput in tokens per second.
+        hourly_cost: Total hourly instance cost in USD.
+
+    Returns:
+        CPMT value in USD. Returns ``float('inf')`` if throughput is zero
+        or negative.
+    """
+    if throughput_tok_per_sec <= 0:
+        return float("inf")
+
+    million_tokens = 1_000_000
+    ttmt_seconds = million_tokens / throughput_tok_per_sec
+    cpmt = (ttmt_seconds * hourly_cost) / 3600
+    return cpmt
+
+
+# ===================================================================== #
+#  SLO filtering                                                         #
+# ===================================================================== #
+
+
+def filter_by_slo(
+    results: List[Dict[str, Any]],
+    max_itl_p95_ms: Optional[float] = None,
+    max_ttft_p95_ms: Optional[float] = None,
+) -> List[Dict[str, Any]]:
+    """Filter a list of result dicts by latency SLO constraints.
+
+    Each result dict is expected to have optional keys ``itl_p95_ms``
+    and ``ttft_p95_ms``.
+
+    Args:
+        results: List of result dicts (each containing latency fields).
+        max_itl_p95_ms: Maximum acceptable Inter-Token Latency P95 in
+            milliseconds. Results exceeding this are filtered out.
+        max_ttft_p95_ms: Maximum acceptable Time-to-First-Token P95 in
+            milliseconds. Results exceeding this are filtered out.
+
+    Returns:
+        Filtered list of result dicts that meet all specified SLO
+        constraints.
+    """
+    filtered = results
+
+    if max_itl_p95_ms is not None:
+        filtered = [
+            r
+            for r in filtered
+            if r.get("itl_p95_ms") is None or r["itl_p95_ms"] <= max_itl_p95_ms
+        ]
+
+    if max_ttft_p95_ms is not None:
+        filtered = [
+            r
+            for r in filtered
+            if r.get("ttft_p95_ms") is None or r["ttft_p95_ms"] <= max_ttft_p95_ms
+        ]
+
+    return filtered
+
+
+# ===================================================================== #
+#  Cost comparison helper                                                #
+# ===================================================================== #
+
+
+def compare_cost_efficiency(
+    baseline_cpmt: float,
+    current_cpmt: float,
+) -> dict:
+    """Compare two CPMT values and return the percentage improvement.
+
+    A negative CPMT change means the current configuration is cheaper
+    (better).
+
+    Args:
+        baseline_cpmt: CPMT from the baseline run (USD).
+        current_cpmt: CPMT from the current run (USD).
+
+    Returns:
+        Dict with ``baseline_cpmt``, ``current_cpmt``,
+        ``absolute_change``, ``percent_change``, and ``direction``.
+    """
+    if baseline_cpmt <= 0 or baseline_cpmt == float("inf"):
+        pct = 0.0
+    else:
+        pct = ((current_cpmt - baseline_cpmt) / baseline_cpmt) * 100.0
+
+    abs_change = current_cpmt - baseline_cpmt
+
+    if pct < -2:
+        direction = "cheaper"
+    elif pct > 2:
+        direction = "more_expensive"
+    else:
+        direction = "similar"
+
+    return {
+        "baseline_cpmt": round(baseline_cpmt, 4),
+        "current_cpmt": round(current_cpmt, 4),
+        "absolute_change": round(abs_change, 4),
+        "percent_change": round(pct, 2),
+        "direction": direction,
+    }
+
+
+# ===================================================================== #
+#  Internal helpers                                                      #
+# ===================================================================== #
+
+
+def _resolve_accelerator(name: str) -> Optional[str]:
+    """Case-insensitive lookup into ACCELERATOR_PRICING.
+
+    Returns the canonical key if found, else ``None``.
+    """
+    upper = name.upper().strip()
+    for key in ACCELERATOR_PRICING:
+        if key.upper() == upper:
+            return key
+    # Substring fallback (e.g. "h200" matches "H200")
+    for key in ACCELERATOR_PRICING:
+        if upper in key.upper() or key.upper() in upper:
+            return key
+    return None
+
+
+def _get_hourly_cost(accelerator_key: str) -> float:
+    """Return the hourly cost for a known accelerator key."""
+    entry = ACCELERATOR_PRICING.get(accelerator_key, {})
+    if isinstance(entry, dict):
+        return entry.get("hourly_cost", 0.0)
+    return float(entry)
+
+
+def _get_gpus_per_instance(accelerator_key: str) -> int:
+    """Return GPUs per instance for a known accelerator key."""
+    entry = ACCELERATOR_PRICING.get(accelerator_key, {})
+    if isinstance(entry, dict):
+        return entry.get("gpus_per_instance", 8)
+    return 8
+
+
+# ===================================================================== #
+#  Main entry point                                                      #
+# ===================================================================== #
+
+
+def calculate_cost(
+    throughput: float,
+    accelerator: str = "h100",
+    tp: int = 1,
+    hourly_cost_override: Optional[float] = None,
+    itl_p95_ms: Optional[float] = None,
+    ttft_p95_ms: Optional[float] = None,
+) -> dict:
+    """Calculate cost-efficiency metrics for an inference configuration.
+
+    This is the primary entry point. Given a throughput measurement and an
+    accelerator type (or custom hourly cost), it computes CPMT, time to
+    million tokens, efficiency score, and embeds pricing metadata.
+
+    For GPU accelerators (H200, MI300X, H100, A100) the calculation
+    adjusts throughput to reflect the full instance: if you measure
+    throughput with TP=2 on an 8-GPU box, the effective throughput is
+    ``raw_throughput * (8 / 2)`` because you could run 4 independent
+    replicas.
+
+    For TPU the cost scales with the TP count instead (per-core pricing).
+
+    Args:
+        throughput: Measured output throughput in tokens per second.
+        accelerator: Accelerator name (e.g. ``"h100"``, ``"H200"``,
+            ``"MI300X"``). Case-insensitive.
+        tp: Tensor-parallelism degree used during the benchmark
+            (default 1).
+        hourly_cost_override: If provided, use this hourly cost (USD)
+            instead of looking up ``ACCELERATOR_PRICING``.
+        itl_p95_ms: Optional measured ITL P95 latency in ms (included
+            in output for SLO-aware analysis).
+        ttft_p95_ms: Optional measured TTFT P95 latency in ms.
+
+    Returns:
+        Dict with keys:
+        - ``status``: ``"success"`` or ``"error"``
+        - ``accelerator``: Canonical accelerator name.
+        - ``raw_throughput_tok_per_sec``
+        - ``effective_throughput_tok_per_sec``
+        - ``hourly_cost_usd``
+        - ``cost_per_million_tokens_usd`` (CPMT)
+        - ``time_to_million_tokens_seconds``
+        - ``time_to_million_tokens_minutes``
+        - ``efficiency_score`` (tokens per dollar-hour)
+        - ``pricing_info``: Pricing metadata dict.
+        - ``latency``: Optional latency values.
+    """
+    try:
+        if throughput <= 0:
+            return {
+                "status": "error",
+                "message": "Throughput must be a positive number.",
+            }
+
+        # Resolve accelerator
+        acc_key = _resolve_accelerator(accelerator)
+        if acc_key is None and hourly_cost_override is None:
+            return {
+                "status": "error",
+                "message": (
+                    f"Unknown accelerator '{accelerator}'. "
+                    f"Available: {list(ACCELERATOR_PRICING.keys())}. "
+                    "Or provide hourly_cost_override."
+                ),
+            }
+
+        # Determine hourly cost
+        if hourly_cost_override is not None:
+            hourly_cost = hourly_cost_override
+            pricing_info = {
+                "source": "custom_override",
+                "hourly_cost": hourly_cost,
+            }
+        else:
+            hourly_cost = _get_hourly_cost(acc_key)
+            pricing_info = dict(ACCELERATOR_PRICING.get(acc_key, {}))
+
+        # Compute effective throughput and total hourly cost
+        is_tpu = acc_key is not None and acc_key.upper() == "TPU"
+        if is_tpu:
+            # TPU: per-core pricing -- cost scales with TP
+            total_hourly_cost = hourly_cost * max(tp, 1)
+            effective_throughput = throughput
+            throughput_note = "Raw throughput (per-core pricing)"
+        else:
+            # GPU: full-instance pricing -- throughput scales with instance
+            total_hourly_cost = hourly_cost
+            gpus_per_instance = _get_gpus_per_instance(acc_key) if acc_key else 8
+            effective_throughput = throughput * (gpus_per_instance / max(tp, 1))
+            throughput_note = (
+                f"Adjusted throughput ({gpus_per_instance}-GPU instance, TP={tp})"
+            )
+
+        # CPMT
+        cpmt = calculate_cpmt(effective_throughput, total_hourly_cost)
+
+        # Time to million tokens
+        million = 1_000_000
+        if effective_throughput > 0:
+            ttmt_sec = million / effective_throughput
+            ttmt_min = ttmt_sec / 60
+        else:
+            ttmt_sec = float("inf")
+            ttmt_min = float("inf")
+
+        # Efficiency score (tokens per dollar-hour)
+        efficiency = (
+            effective_throughput / total_hourly_cost if total_hourly_cost > 0 else 0.0
+        )
+
+        result: Dict[str, Any] = {
+            "status": "success",
+            "accelerator": acc_key or accelerator,
+            "tp": tp,
+            "raw_throughput_tok_per_sec": round(throughput, 2),
+            "effective_throughput_tok_per_sec": round(effective_throughput, 2),
+            "throughput_note": throughput_note,
+            "hourly_cost_usd": round(total_hourly_cost, 2),
+            "cost_per_million_tokens_usd": (
+                round(cpmt, 4) if cpmt != float("inf") else None
+            ),
+            "time_to_million_tokens_seconds": (
+                round(ttmt_sec, 2) if ttmt_sec != float("inf") else None
+            ),
+            "time_to_million_tokens_minutes": (
+                round(ttmt_min, 2) if ttmt_min != float("inf") else None
+            ),
+            "efficiency_score_tokens_per_dollar_hour": round(efficiency, 2),
+            "pricing_info": pricing_info,
+        }
+
+        # Attach latency if provided
+        if itl_p95_ms is not None or ttft_p95_ms is not None:
+            result["latency"] = {
+                "itl_p95_ms": itl_p95_ms,
+                "ttft_p95_ms": ttft_p95_ms,
+            }
+
+        return result
+
+    except Exception as exc:
+        return {
+            "status": "error",
+            "message": f"Failed to calculate cost: {exc}",
+        }

--- a/auto_tune_vllm/agent/analysis/kernel_mapper.py
+++ b/auto_tune_vllm/agent/analysis/kernel_mapper.py
@@ -1,0 +1,439 @@
+"""
+Kernel-to-Source-Code Mapper
+
+Maps CUDA kernel names to their vLLM/PyTorch source code locations
+and provides human-readable descriptions of kernel functionality.
+
+SOURCE: AI-Analysis-Agent/psap-mcp-server/psap_mcp_server/src/tools/kernel_code_mapper_tool.py
+
+Converted to sync plain Python functions. No MCP, async, httpx, or logger.
+
+Public API:
+    map_kernel(kernel_name: str) -> dict
+        Main entry point. Returns source info, category, description.
+
+    find_kernel_mapping(kernel_name: str) -> list[dict]
+    is_pytorch_stdlib(kernel_name: str) -> bool
+
+Constants:
+    KERNEL_MAPPINGS
+    PYTORCH_STDLIB_OPS
+"""
+
+import re
+from typing import Dict, List
+
+# ===================================================================== #
+#  Curated kernel-to-source mappings                                     #
+# ===================================================================== #
+# Each entry is (regex_pattern, [(path, confidence, description), ...]).
+
+KERNEL_MAPPINGS = [
+    # Flash Attention kernels
+    (
+        r"flash_attn.*|FlashAttn.*",
+        [
+            (
+                "vllm/attention/backends/flash_attn.py",
+                "high",
+                "Flash Attention backend implementation",
+            ),
+            ("vllm/attention/ops/", "medium", "Attention operation implementations"),
+            ("csrc/attention/", "medium", "C++/CUDA attention kernels"),
+        ],
+    ),
+    # PagedAttention kernels
+    (
+        r"paged_attention.*|PagedAttention.*",
+        [
+            ("vllm/attention/backends/", "high", "Paged attention backend"),
+            (
+                "csrc/attention/attention_kernels.cu",
+                "high",
+                "CUDA paged attention kernels",
+            ),
+        ],
+    ),
+    # MoE (Mixture of Experts) kernels -- important for DeepSeek
+    (
+        r".*moe.*|.*expert.*|.*MoE.*|fused_moe.*",
+        [
+            (
+                "vllm/model_executor/layers/fused_moe/",
+                "high",
+                "Fused MoE layer implementations",
+            ),
+            ("csrc/moe/", "high", "C++/CUDA MoE kernels"),
+            ("vllm/model_executor/layers/moe/", "medium", "MoE layer Python code"),
+        ],
+    ),
+    # Quantization kernels
+    (
+        r".*awq.*|.*gptq.*|.*fp8.*|.*int8.*|.*quant.*",
+        [
+            (
+                "vllm/model_executor/layers/quantization/",
+                "high",
+                "Quantization implementations",
+            ),
+            ("csrc/quantization/", "high", "CUDA quantization kernels"),
+        ],
+    ),
+    # GEMM / Matrix multiplication
+    (
+        r"aten::mm|aten::bmm|aten::matmul|aten::linear|cutlass.*gemm.*|cublas.*gemm.*",
+        [
+            (
+                "vllm/model_executor/layers/linear.py",
+                "medium",
+                "Linear layer implementations",
+            ),
+            ("csrc/", "low", "Custom CUDA kernels may override"),
+        ],
+    ),
+    # Activation functions
+    (
+        r"aten::silu|aten::gelu|aten::relu|.*activation.*|silu_and_mul.*",
+        [
+            (
+                "vllm/model_executor/layers/activation.py",
+                "high",
+                "Activation function implementations",
+            ),
+            ("csrc/activation_kernels.cu", "medium", "CUDA activation kernels"),
+        ],
+    ),
+    # LayerNorm / RMSNorm
+    (
+        r".*layer_norm.*|.*rms_norm.*|.*LayerNorm.*|.*RMSNorm.*|aten::layer_norm",
+        [
+            (
+                "vllm/model_executor/layers/layernorm.py",
+                "high",
+                "LayerNorm implementations",
+            ),
+            ("csrc/layernorm_kernels.cu", "medium", "CUDA LayerNorm kernels"),
+        ],
+    ),
+    # Rotary embeddings
+    (
+        r".*rotary.*|.*rope.*|.*RoPE.*",
+        [
+            (
+                "vllm/model_executor/layers/rotary_embedding.py",
+                "high",
+                "Rotary embedding implementations",
+            ),
+            (
+                "csrc/pos_encoding_kernels.cu",
+                "medium",
+                "CUDA position encoding kernels",
+            ),
+        ],
+    ),
+    # Sampling / Top-k/p
+    (
+        r".*sample.*|.*topk.*|.*topp.*|.*argmax.*",
+        [
+            (
+                "vllm/model_executor/layers/sampler.py",
+                "high",
+                "Sampling implementations",
+            ),
+            ("csrc/", "low", "CUDA sampling kernels"),
+        ],
+    ),
+    # Communication / NCCL
+    (
+        r"nccl.*|ncclAllReduce.*|ncclAllGather.*|c10d.*",
+        [
+            ("vllm/distributed/", "high", "Distributed communication code"),
+            ("vllm/executor/", "medium", "Executor implementations"),
+        ],
+    ),
+    # Memory operations
+    (
+        r"aten::copy_|aten::clone|aten::contiguous|aten::to|cudaMemcpy.*",
+        [
+            ("vllm/worker/", "medium", "Worker implementations handle memory"),
+            ("vllm/attention/backends/", "low", "Attention backends may copy tensors"),
+        ],
+    ),
+    # KV Cache operations
+    (
+        r".*kv_cache.*|.*cache_copy.*|.*reshape_and_cache.*",
+        [
+            (
+                "vllm/attention/backends/",
+                "high",
+                "KV cache operations in attention backends",
+            ),
+            ("csrc/cache_kernels.cu", "high", "CUDA cache kernels"),
+            ("vllm/worker/cache_engine.py", "medium", "Cache engine implementation"),
+        ],
+    ),
+    # Embedding operations
+    (
+        r"aten::embedding|.*embed.*",
+        [
+            (
+                "vllm/model_executor/layers/vocab_parallel_embedding.py",
+                "high",
+                "Embedding layer implementations",
+            ),
+        ],
+    ),
+    # Softmax
+    (
+        r"aten::softmax|aten::_softmax|.*softmax.*",
+        [
+            ("vllm/attention/", "medium", "Softmax used in attention"),
+            ("csrc/attention/", "medium", "CUDA attention with fused softmax"),
+        ],
+    ),
+    # Custom vLLM ops
+    (
+        r"vllm::.*",
+        [
+            ("csrc/", "high", "Custom vLLM CUDA ops"),
+            ("vllm/", "medium", "Python wrapper code"),
+        ],
+    ),
+    # Triton kernels
+    (
+        r"triton.*|Triton.*",
+        [
+            ("vllm/attention/ops/", "high", "Triton attention kernels"),
+            ("vllm/model_executor/layers/fused_moe/", "medium", "Triton MoE kernels"),
+        ],
+    ),
+]
+
+
+# ===================================================================== #
+#  PyTorch standard-library ops (not vLLM-specific)                      #
+# ===================================================================== #
+
+PYTORCH_STDLIB_OPS = [
+    r"aten::empty.*",
+    r"aten::zeros.*",
+    r"aten::ones.*",
+    r"aten::view.*",
+    r"aten::reshape.*",
+    r"aten::transpose.*",
+    r"aten::permute.*",
+    r"aten::squeeze.*",
+    r"aten::unsqueeze.*",
+    r"aten::cat.*",
+    r"aten::stack.*",
+    r"aten::split.*",
+    r"aten::chunk.*",
+    r"aten::select.*",
+    r"aten::slice.*",
+    r"aten::index.*",
+    r"aten::as_strided.*",
+    r"aten::expand.*",
+    r"aten::repeat.*",
+    r"aten::fill_.*",
+    r"aten::zero_.*",
+    r"aten::add.*",
+    r"aten::sub.*",
+    r"aten::mul.*",
+    r"aten::div.*",
+    r"aten::pow.*",
+    r"aten::sqrt.*",
+    r"aten::rsqrt.*",
+    r"aten::exp.*",
+    r"aten::log.*",
+    r"aten::abs.*",
+    r"aten::neg.*",
+    r"aten::sum.*",
+    r"aten::mean.*",
+    r"aten::max.*",
+    r"aten::min.*",
+    r"aten::where.*",
+    r"aten::masked.*",
+    r"aten::scatter.*",
+    r"aten::gather.*",
+]
+
+
+# ===================================================================== #
+#  Core functions                                                        #
+# ===================================================================== #
+
+
+def is_pytorch_stdlib(kernel_name: str) -> bool:
+    """Check whether a kernel name is a standard PyTorch ATen operation.
+
+    These operations are implemented in PyTorch core rather than in
+    vLLM custom code.
+
+    Args:
+        kernel_name: The kernel / operation name from a profiler trace.
+
+    Returns:
+        ``True`` if the kernel matches any ``PYTORCH_STDLIB_OPS`` pattern.
+    """
+    for pattern in PYTORCH_STDLIB_OPS:
+        if re.match(pattern, kernel_name, re.IGNORECASE):
+            return True
+    return False
+
+
+def find_kernel_mapping(kernel_name: str) -> List[Dict[str, str]]:
+    """Find likely vLLM source-file locations for a kernel name.
+
+    Matches *kernel_name* against ``KERNEL_MAPPINGS`` patterns and returns
+    all matching entries with path, confidence level, description, and the
+    pattern that matched.
+
+    Args:
+        kernel_name: The kernel / operation name from a profiler trace.
+
+    Returns:
+        List of dicts, each with keys ``path``, ``confidence``,
+        ``description``, ``matched_pattern``.  May be empty if no
+        pattern matches.
+    """
+    results = []
+    for pattern, mappings in KERNEL_MAPPINGS:
+        if re.search(pattern, kernel_name, re.IGNORECASE):
+            for path, confidence, description in mappings:
+                results.append(
+                    {
+                        "path": path,
+                        "confidence": confidence,
+                        "description": description,
+                        "matched_pattern": pattern,
+                    }
+                )
+    return results
+
+
+def _infer_category(kernel_name: str, mappings: List[Dict[str, str]]) -> str:
+    """Infer a human-readable category from the kernel name or its mappings.
+
+    Uses simple heuristics on the file paths / kernel name to assign a
+    broad category label.
+    """
+    lower = kernel_name.lower()
+
+    # Check paths from mappings first
+    all_paths = " ".join(m.get("path", "") for m in mappings).lower()
+
+    if "attention" in lower or "attention" in all_paths:
+        return "attention"
+    if "moe" in lower or "expert" in lower or "fused_moe" in all_paths:
+        return "moe"
+    if "quant" in lower or "fp8" in lower or "quantization" in all_paths:
+        return "quantization"
+    if "nccl" in lower or "allreduce" in lower or "distributed" in all_paths:
+        return "communication"
+    if "norm" in lower or "layernorm" in all_paths:
+        return "normalization"
+    if "activation" in lower or "silu" in lower or "gelu" in lower:
+        return "activation"
+    if "gemm" in lower or "matmul" in lower or "linear" in all_paths:
+        return "gemm_linear"
+    if "cache" in lower:
+        return "kv_cache"
+    if "embed" in lower:
+        return "embedding"
+    if "sample" in lower or "topk" in lower:
+        return "sampling"
+    if "rotary" in lower or "rope" in lower:
+        return "rotary_embedding"
+    if "softmax" in lower:
+        return "softmax"
+    if "triton" in lower:
+        return "triton"
+    if lower.startswith("vllm::"):
+        return "vllm_custom"
+    if lower.startswith("aten::"):
+        return "pytorch_aten"
+    if lower.startswith("cuda"):
+        return "cuda_runtime"
+
+    return "other"
+
+
+# ===================================================================== #
+#  Main entry point                                                      #
+# ===================================================================== #
+
+
+def map_kernel(kernel_name: str) -> dict:
+    """Map a kernel / operation name to its source info, category, and description.
+
+    This is the primary entry point. It combines ``find_kernel_mapping``,
+    ``is_pytorch_stdlib``, and category inference into a single convenient
+    call.
+
+    Args:
+        kernel_name: The kernel name from a PyTorch profiler trace
+            (e.g. ``"flash_attn_v2_fwd"``, ``"fused_moe_kernel"``,
+            ``"aten::mm"``).
+
+    Returns:
+        Dict with keys:
+        - ``kernel_name``: The input name.
+        - ``is_pytorch_stdlib``: Whether it is a standard PyTorch op.
+        - ``category``: Inferred broad category string.
+        - ``likely_source_files``: List of source-location dicts (may be
+          empty).
+        - ``description``: Human-readable summary.
+        - ``suggestions``: List of follow-up suggestions.
+    """
+    stdlib = is_pytorch_stdlib(kernel_name)
+    mappings = find_kernel_mapping(kernel_name)
+    category = _infer_category(kernel_name, mappings)
+
+    # Build a concise description
+    if stdlib:
+        description = (
+            f"'{kernel_name}' is a standard PyTorch ATen operation "
+            "implemented in PyTorch core, not vLLM-specific."
+        )
+    elif mappings:
+        top = mappings[0]
+        description = (
+            f"'{kernel_name}' likely maps to {top['path']} "
+            f"({top['confidence']} confidence): {top['description']}."
+        )
+    else:
+        description = (
+            f"No curated mapping found for '{kernel_name}'. "
+            "It may be from a third-party library or a newly added kernel."
+        )
+
+    # Suggestions for further investigation
+    suggestions: List[str] = []
+    if stdlib:
+        suggestions.append(
+            "This is a standard PyTorch operation. Performance may be "
+            "affected by how vLLM uses this op (tensor shapes, dtypes)."
+        )
+    elif not mappings:
+        suggestions.append(
+            f"Try searching the vLLM repo for '{kernel_name}' to find "
+            "the implementation."
+        )
+        suggestions.append(
+            "Check if this kernel is from a third-party library "
+            "(e.g., flash-attn, triton, deep_gemm)."
+        )
+    else:
+        suggestions.append(
+            "Review the source files listed above to understand the "
+            "kernel implementation."
+        )
+
+    return {
+        "kernel_name": kernel_name,
+        "is_pytorch_stdlib": stdlib,
+        "category": category,
+        "likely_source_files": mappings,
+        "description": description,
+        "suggestions": suggestions,
+    }

--- a/auto_tune_vllm/agent/analysis/regression.py
+++ b/auto_tune_vllm/agent/analysis/regression.py
@@ -1,0 +1,267 @@
+"""
+Performance Regression Detection
+
+Compares benchmark results between two runs (baseline vs. current) and
+detects performance regressions or improvements beyond a configurable
+threshold.
+
+SOURCE: AI-Analysis-Agent/psap-mcp-server/psap_mcp_server/src/tools/regression_analysis_tool.py
+
+Converted to sync plain Python functions. No MCP, S3, async, pandas,
+or logger.
+
+Public API:
+    detect_regression(baseline: dict, current: dict, threshold: float = 0.02) -> dict
+        Main entry point. Compares two benchmark result dicts and returns
+        per-metric regressions, improvements, and a summary.
+
+Metric directionality:
+    - Throughput metrics (tok/sec): higher is better.
+    - Latency metrics (ttft, itl, tpot): lower is better.
+"""
+
+from typing import Any, Dict, List, Optional
+
+# ===================================================================== #
+#  Metric directionality                                                 #
+# ===================================================================== #
+
+# Keywords that indicate "higher is better" metrics.
+_HIGHER_IS_BETTER_KEYWORDS = ["tok/sec", "throughput", "tokens_per_sec"]
+
+# Keywords that indicate "lower is better" metrics.
+_LOWER_IS_BETTER_KEYWORDS = [
+    "ttft",
+    "itl",
+    "tpot",
+    "latency",
+    "p50",
+    "p95",
+    "p99",
+    "median",
+    "mean",
+]
+
+
+def _is_higher_better(metric_name: str) -> bool:
+    """Return True if a higher value for *metric_name* means better performance."""
+    lower = metric_name.lower()
+    if any(kw in lower for kw in _HIGHER_IS_BETTER_KEYWORDS):
+        return True
+    if any(kw in lower for kw in _LOWER_IS_BETTER_KEYWORDS):
+        return False
+    # Default: assume higher is better (e.g. generic scores).
+    return True
+
+
+# ===================================================================== #
+#  Core comparison logic                                                 #
+# ===================================================================== #
+
+
+def _compare_metric(
+    metric_name: str,
+    baseline_val: float,
+    current_val: float,
+    threshold: float,
+) -> Dict[str, Any]:
+    """Compare a single metric value between baseline and current.
+
+    Args:
+        metric_name: Name of the metric.
+        baseline_val: Value from the baseline run.
+        current_val: Value from the current run.
+        threshold: Fractional threshold for flagging regression/improvement
+            (e.g. 0.02 = 2%).
+
+    Returns:
+        Dict with comparison details including percentage change and
+        direction.
+    """
+    if baseline_val == 0:
+        pct_change = 100.0 if current_val != 0 else 0.0
+    else:
+        pct_change = ((current_val - baseline_val) / baseline_val) * 100.0
+
+    abs_change = current_val - baseline_val
+    higher_better = _is_higher_better(metric_name)
+
+    # Determine direction
+    if higher_better:
+        if pct_change > threshold * 100:
+            direction = "improvement"
+        elif pct_change < -threshold * 100:
+            direction = "regression"
+        else:
+            direction = "neutral"
+    else:
+        # Lower is better: a negative pct_change is improvement.
+        if pct_change < -threshold * 100:
+            direction = "improvement"
+        elif pct_change > threshold * 100:
+            direction = "regression"
+        else:
+            direction = "neutral"
+
+    return {
+        "metric": metric_name,
+        "baseline_value": round(baseline_val, 4),
+        "current_value": round(current_val, 4),
+        "absolute_change": round(abs_change, 4),
+        "percent_change": round(pct_change, 2),
+        "direction": direction,
+        "higher_is_better": higher_better,
+    }
+
+
+# ===================================================================== #
+#  Main entry point                                                      #
+# ===================================================================== #
+
+
+def detect_regression(
+    baseline: dict,
+    current: dict,
+    threshold: float = 0.02,
+    metrics: Optional[List[str]] = None,
+) -> dict:
+    """Compare two benchmark result dicts and detect regressions.
+
+    Both *baseline* and *current* should be flat dicts mapping metric names
+    to numeric values.  For example::
+
+        baseline = {
+            "output_tok/sec": 1200.5,
+            "ttft_median": 45.3,
+            "ttft_p95": 78.1,
+            "itl_median": 12.4,
+            "itl_p95": 18.7,
+        }
+        current = {
+            "output_tok/sec": 1150.0,
+            "ttft_median": 48.9,
+            "ttft_p95": 82.5,
+            "itl_median": 11.8,
+            "itl_p95": 19.2,
+        }
+
+    Args:
+        baseline: Metric-name to value dict from the baseline run.
+        current: Metric-name to value dict from the current run.
+        threshold: Fractional threshold for flagging a change as
+            regression or improvement.  Default ``0.02`` (2%).
+        metrics: Optional explicit list of metric names to compare.
+            If ``None``, all numeric keys common to both dicts are
+            compared.
+
+    Returns:
+        Dict with keys:
+        - ``status``: ``"success"`` or ``"error"``
+        - ``threshold``: The threshold used (as a fraction).
+        - ``comparisons``: List of per-metric comparison dicts.
+        - ``regressions``: Subset of comparisons flagged as regressions.
+        - ``improvements``: Subset of comparisons flagged as improvements.
+        - ``no_change``: Subset within the neutral band.
+        - ``summary``: High-level counts and overall verdict.
+    """
+    try:
+        if not baseline or not current:
+            return {
+                "status": "error",
+                "message": "Both baseline and current results are required.",
+            }
+
+        # Determine which metrics to compare
+        if metrics is not None:
+            keys_to_compare = [k for k in metrics if k in baseline and k in current]
+        else:
+            # Use all common numeric keys
+            keys_to_compare = sorted(
+                k
+                for k in set(baseline.keys()) & set(current.keys())
+                if isinstance(baseline[k], (int, float))
+                and isinstance(current[k], (int, float))
+            )
+
+        if not keys_to_compare:
+            return {
+                "status": "error",
+                "message": (
+                    "No common numeric metrics found between baseline and "
+                    "current results."
+                ),
+            }
+
+        comparisons: List[Dict[str, Any]] = []
+        regressions: List[Dict[str, Any]] = []
+        improvements: List[Dict[str, Any]] = []
+        no_change: List[Dict[str, Any]] = []
+
+        for key in keys_to_compare:
+            b_val = float(baseline[key])
+            c_val = float(current[key])
+            result = _compare_metric(key, b_val, c_val, threshold)
+            comparisons.append(result)
+
+            if result["direction"] == "regression":
+                regressions.append(result)
+            elif result["direction"] == "improvement":
+                improvements.append(result)
+            else:
+                no_change.append(result)
+
+        # Sort regressions by magnitude (worst first)
+        regressions.sort(key=lambda x: abs(x["percent_change"]), reverse=True)
+        improvements.sort(key=lambda x: abs(x["percent_change"]), reverse=True)
+
+        # Overall verdict
+        if regressions and not improvements:
+            verdict = "regression"
+        elif improvements and not regressions:
+            verdict = "improvement"
+        elif regressions and improvements:
+            verdict = "mixed"
+        else:
+            verdict = "no_significant_change"
+
+        total_compared = len(comparisons)
+        summary = {
+            "total_metrics_compared": total_compared,
+            "regressions_count": len(regressions),
+            "improvements_count": len(improvements),
+            "no_change_count": len(no_change),
+            "regression_rate": (
+                round(len(regressions) / total_compared * 100, 2)
+                if total_compared > 0
+                else 0
+            ),
+            "improvement_rate": (
+                round(len(improvements) / total_compared * 100, 2)
+                if total_compared > 0
+                else 0
+            ),
+            "verdict": verdict,
+        }
+
+        return {
+            "status": "success",
+            "threshold": threshold,
+            "comparisons": comparisons,
+            "regressions": regressions,
+            "improvements": improvements,
+            "no_change": no_change,
+            "summary": summary,
+            "message": (
+                f"Compared {total_compared} metrics: "
+                f"{len(regressions)} regressions, "
+                f"{len(improvements)} improvements, "
+                f"{len(no_change)} unchanged "
+                f"(threshold={threshold * 100:.1f}%)"
+            ),
+        }
+
+    except Exception as exc:
+        return {
+            "status": "error",
+            "message": f"Failed to detect regressions: {exc}",
+        }

--- a/auto_tune_vllm/agent/analysis/trace_analyzer.py
+++ b/auto_tune_vllm/agent/analysis/trace_analyzer.py
@@ -1,0 +1,496 @@
+"""
+PyTorch Profiler Trace Analyzer
+
+Parses Chrome trace JSON files from PyTorch profiler and extracts
+kernel-level performance statistics.
+
+SOURCE: AI-Analysis-Agent/psap-mcp-server/psap_mcp_server/src/tools/pytorch_profile_tool.py
+
+Converted to sync plain Python functions. No MCP, S3, async, or logger.
+
+Public API:
+    analyze_trace(trace_json: dict) -> dict
+        Main entry point. Returns kernel stats, top kernels, category breakdown.
+
+    extract_kernel_stats(trace: dict) -> dict
+    merge_stats(stats_list: list) -> dict
+    get_top_kernels(stats: dict, n: int = 20) -> list
+    get_category_breakdown(stats: dict) -> dict
+    classify_kernel(kernel_name: str) -> str | None
+
+Constants:
+    FUNCTIONAL_PIPELINES
+    CATEGORY_GROUPS
+"""
+
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
+# ---------------------------------------------------------------------------
+# Functional pipeline grouping: maps high-level execution pipelines to kernel
+# name patterns.  Used to produce a category-level breakdown comparable to
+# what a human expert would write.
+# ---------------------------------------------------------------------------
+FUNCTIONAL_PIPELINES: Dict[str, Dict[str, Any]] = {
+    "moe_execution": {
+        "patterns": [
+            "moe",
+            "expert",
+            "scatter",
+            "gather",
+            "fused_moe",
+            "deep_gemm",
+            "outplace_fused",
+        ],
+        "description": "MoE routing + expert GEMM execution pipeline",
+    },
+    "attention": {
+        "patterns": [
+            "attention",
+            "flash",
+            "mla",
+            "paged",
+            "kv_cache",
+            "reshape_and_cache",
+        ],
+        "description": "Attention mechanism (MLA / MHA / GQA / Flash / Paged)",
+    },
+    "communication": {
+        "patterns": [
+            "nccl",
+            "allreduce",
+            "allgather",
+            "multimem",
+            "c10d",
+            "all_reduce",
+        ],
+        "description": "Inter-GPU collective communication",
+    },
+    "quantization": {
+        "patterns": [
+            "quant",
+            "fp8",
+            "int8",
+            "dequant",
+            "scale",
+            "per_token_group",
+        ],
+        "description": "Quantization / dequantization / scaling operations",
+    },
+    "normalization_activation": {
+        "patterns": [
+            "layernorm",
+            "rmsnorm",
+            "rms_norm",
+            "silu",
+            "gelu",
+            "activation",
+            "act_and_mul",
+        ],
+        "description": "Normalization (RMSNorm/LayerNorm) and activation functions",
+    },
+    "gemm_linear": {
+        "patterns": [
+            "gemm",
+            "matmul",
+            "aten::mm",
+            "aten::bmm",
+            "aten::linear",
+            "cublas",
+            "cutlass",
+        ],
+        "description": "Standalone matrix multiplication / linear layers (not MoE)",
+    },
+}
+
+# Category groups for filtering trace events by their ``cat`` field.
+CATEGORY_GROUPS: Dict[str, Optional[List[str]]] = {
+    "kernel": ["kernel"],
+    "cpu": ["cpu_op"],
+    "cuda": ["cuda_runtime", "cuda_driver"],
+    "communication": ["nccl", "c10d"],
+    "memory": ["cuda_memory"],
+    "all": None,
+}
+
+
+# ===================================================================== #
+#  Core stat-extraction functions                                        #
+# ===================================================================== #
+
+
+def extract_kernel_stats(trace: dict) -> Dict[str, Dict]:
+    """Extract kernel statistics from a Chrome trace JSON dict.
+
+    Looks for complete-duration events (``ph == "X"``) and aggregates per
+    unique operation name: invocation count, total / avg / min / max
+    duration, and the trace category.
+
+    Args:
+        trace: Parsed Chrome trace JSON (must contain ``traceEvents``).
+
+    Returns:
+        Dict mapping ``kernel_name`` to a stats dict with keys:
+        ``count``, ``total_dur``, ``avg_dur``, ``min_dur``, ``max_dur``,
+        ``cat``.
+    """
+    stats: Dict[str, Dict] = defaultdict(
+        lambda: {
+            "count": 0,
+            "total_dur": 0,
+            "min_dur": float("inf"),
+            "max_dur": 0,
+            "cat": "",
+        }
+    )
+
+    for event in trace.get("traceEvents", []):
+        if event.get("ph") == "X":
+            name = event.get("name", "unknown")
+            dur = event.get("dur", 0)
+            cat = event.get("cat", "")
+            if dur > 0:
+                stats[name]["count"] += 1
+                stats[name]["total_dur"] += dur
+                stats[name]["min_dur"] = min(stats[name]["min_dur"], dur)
+                stats[name]["max_dur"] = max(stats[name]["max_dur"], dur)
+                if not stats[name]["cat"]:
+                    stats[name]["cat"] = cat
+
+    for data in stats.values():
+        data["avg_dur"] = data["total_dur"] / data["count"] if data["count"] > 0 else 0
+        if data["min_dur"] == float("inf"):
+            data["min_dur"] = 0
+
+    return dict(stats)
+
+
+def merge_stats(stats_list: List[Dict[str, Dict]]) -> Dict[str, Dict]:
+    """Merge statistics from multiple ranks / traces into one view.
+
+    Args:
+        stats_list: List of per-rank stats dicts (as returned by
+            ``extract_kernel_stats``).
+
+    Returns:
+        A single merged stats dict.
+    """
+    merged: Dict[str, Dict] = defaultdict(
+        lambda: {
+            "count": 0,
+            "total_dur": 0,
+            "min_dur": float("inf"),
+            "max_dur": 0,
+            "cat": "",
+        }
+    )
+
+    for stats in stats_list:
+        for name, data in stats.items():
+            merged[name]["count"] += data["count"]
+            merged[name]["total_dur"] += data["total_dur"]
+            merged[name]["min_dur"] = min(
+                merged[name]["min_dur"],
+                data.get("min_dur", float("inf")),
+            )
+            merged[name]["max_dur"] = max(
+                merged[name]["max_dur"],
+                data.get("max_dur", 0),
+            )
+            if not merged[name]["cat"]:
+                merged[name]["cat"] = data.get("cat", "")
+
+    for data in merged.values():
+        data["avg_dur"] = data["total_dur"] / data["count"] if data["count"] > 0 else 0
+        if data["min_dur"] == float("inf"):
+            data["min_dur"] = 0
+
+    return dict(merged)
+
+
+# ===================================================================== #
+#  Formatting helper                                                     #
+# ===================================================================== #
+
+
+def _format_duration(us: float) -> str:
+    """Format a duration given in microseconds to a human-readable string."""
+    if us >= 1_000_000:
+        return f"{us / 1_000_000:.2f}s"
+    elif us >= 1_000:
+        return f"{us / 1_000:.2f}ms"
+    else:
+        return f"{us:.2f}\u00b5s"
+
+
+# ===================================================================== #
+#  Top-kernels & category breakdown                                      #
+# ===================================================================== #
+
+
+def get_top_kernels(
+    stats: Dict[str, Dict],
+    n: int = 20,
+    sort_by: str = "total_dur",
+) -> List[Dict]:
+    """Return the top *n* kernels sorted by the chosen metric.
+
+    Args:
+        stats: Kernel stats dict (from ``extract_kernel_stats`` or
+            ``merge_stats``).
+        n: Number of kernels to return (default 20).
+        sort_by: Stats key to sort by (default ``"total_dur"``).
+
+    Returns:
+        List of dicts, each with keys: ``name``, ``category``, ``count``,
+        ``total_dur_us``, ``total_dur_human``, ``avg_dur_us``,
+        ``avg_dur_human``, ``min_dur_us``, ``max_dur_us``.
+    """
+    sorted_kernels = sorted(
+        stats.items(),
+        key=lambda x: x[1].get(sort_by, 0),
+        reverse=True,
+    )
+
+    result = []
+    for name, data in sorted_kernels[:n]:
+        result.append(
+            {
+                "name": name,
+                "category": data.get("cat", "unknown"),
+                "count": data["count"],
+                "total_dur_us": data["total_dur"],
+                "total_dur_human": _format_duration(data["total_dur"]),
+                "avg_dur_us": data.get("avg_dur", 0),
+                "avg_dur_human": _format_duration(data.get("avg_dur", 0)),
+                "min_dur_us": data.get("min_dur", 0),
+                "max_dur_us": data.get("max_dur", 0),
+            }
+        )
+
+    return result
+
+
+def get_category_breakdown(stats: Dict[str, Dict]) -> Dict[str, Dict]:
+    """Aggregate GPU time by trace-event category.
+
+    Args:
+        stats: Kernel stats dict.
+
+    Returns:
+        Dict mapping category name to a summary dict with keys:
+        ``total_dur_us``, ``total_dur_human``, ``invocation_count``,
+        ``unique_operations``.
+    """
+    cat_totals: Dict[str, Dict] = defaultdict(
+        lambda: {"total_dur": 0, "count": 0, "kernel_count": 0}
+    )
+
+    for _name, data in stats.items():
+        cat = data.get("cat", "other") or "other"
+        cat_totals[cat]["total_dur"] += data["total_dur"]
+        cat_totals[cat]["count"] += data["count"]
+        cat_totals[cat]["kernel_count"] += 1
+
+    result = {}
+    for cat, totals in sorted(
+        cat_totals.items(),
+        key=lambda x: x[1]["total_dur"],
+        reverse=True,
+    ):
+        result[cat] = {
+            "total_dur_us": totals["total_dur"],
+            "total_dur_human": _format_duration(totals["total_dur"]),
+            "invocation_count": totals["count"],
+            "unique_operations": totals["kernel_count"],
+        }
+
+    return result
+
+
+# ===================================================================== #
+#  Pipeline classification helper                                        #
+# ===================================================================== #
+
+
+def classify_kernel(kernel_name: str) -> Optional[str]:
+    """Map a kernel name to its functional pipeline category.
+
+    Matches against ``FUNCTIONAL_PIPELINES`` patterns (case-insensitive,
+    substring match). Returns the first matching pipeline name, or
+    ``None`` if no pattern matches.
+
+    Args:
+        kernel_name: The kernel / operation name from the trace.
+
+    Returns:
+        Pipeline name string (e.g. ``"attention"``, ``"moe_execution"``)
+        or ``None``.
+    """
+    lower = kernel_name.lower()
+    for pipeline_name, cfg in FUNCTIONAL_PIPELINES.items():
+        if any(pat in lower for pat in cfg["patterns"]):
+            return pipeline_name
+    return None
+
+
+def _filter_by_category(
+    stats: Dict[str, Dict],
+    category: Optional[str],
+) -> Dict[str, Dict]:
+    """Filter stats to only include a specified category group.
+
+    Args:
+        stats: Kernel stats dict.
+        category: One of the keys in ``CATEGORY_GROUPS``, or ``None``
+            (which means "all").
+
+    Returns:
+        Filtered stats dict.
+    """
+    if category is None or category == "all":
+        return stats
+
+    categories = CATEGORY_GROUPS.get(category.lower())
+    if categories is None:
+        return stats
+
+    lower_cats = [c.lower() for c in categories]
+    return {
+        name: data
+        for name, data in stats.items()
+        if data.get("cat", "").lower() in lower_cats
+    }
+
+
+# ===================================================================== #
+#  Pipeline breakdown (used in comparisons)                              #
+# ===================================================================== #
+
+
+def get_pipeline_breakdown(stats: Dict[str, Dict]) -> List[Dict]:
+    """Compute a functional-pipeline breakdown for a single trace.
+
+    Groups all kernels (events with ``cat == "kernel"``) into the
+    pipelines defined in ``FUNCTIONAL_PIPELINES`` and returns per-pipeline
+    totals.
+
+    Args:
+        stats: Kernel stats dict.
+
+    Returns:
+        List of dicts sorted by total time descending, each with:
+        ``pipeline``, ``description``, ``time_ms``, ``calls``,
+        ``unique_kernels``.
+    """
+    kernel_names = {n for n, d in stats.items() if d.get("cat") == "kernel"}
+
+    assigned: Dict[str, str] = {}
+    for name in kernel_names:
+        nl = name.lower()
+        for pipe_name, pipe_cfg in FUNCTIONAL_PIPELINES.items():
+            if any(pat in nl for pat in pipe_cfg["patterns"]):
+                assigned[name] = pipe_name
+                break
+
+    buckets: Dict[str, Dict[str, float]] = {}
+    for pipe_name in list(FUNCTIONAL_PIPELINES.keys()) + ["other"]:
+        buckets[pipe_name] = {"time_us": 0.0, "calls": 0, "kernels": 0}
+
+    for name in kernel_names:
+        pipe = assigned.get(name, "other")
+        d = stats.get(name, {})
+        buckets[pipe]["time_us"] += d.get("total_dur", 0)
+        buckets[pipe]["calls"] += d.get("count", 0)
+        if d.get("total_dur", 0) > 0:
+            buckets[pipe]["kernels"] += 1
+
+    result = []
+    for pn, b in sorted(
+        buckets.items(),
+        key=lambda x: x[1]["time_us"],
+        reverse=True,
+    ):
+        if b["time_us"] == 0:
+            continue
+        desc = FUNCTIONAL_PIPELINES.get(pn, {}).get("description", "Other kernels")
+        result.append(
+            {
+                "pipeline": pn,
+                "description": desc,
+                "time_ms": round(b["time_us"] / 1e3, 1),
+                "calls": int(b["calls"]),
+                "unique_kernels": int(b["kernels"]),
+            }
+        )
+
+    return result
+
+
+# ===================================================================== #
+#  Main entry point                                                      #
+# ===================================================================== #
+
+
+def analyze_trace(
+    trace_json: dict,
+    top_n: int = 20,
+    category: Optional[str] = None,
+) -> dict:
+    """Analyze a PyTorch profiler Chrome trace JSON.
+
+    This is the primary entry point for trace analysis. It extracts kernel
+    stats, computes top kernels, category breakdown, and pipeline
+    breakdown in one call.
+
+    Args:
+        trace_json: Parsed Chrome trace JSON dict (must contain
+            ``traceEvents``).
+        top_n: Number of top kernels to include (default 20).
+        category: Optional category filter (see ``CATEGORY_GROUPS``).
+
+    Returns:
+        Dict with keys:
+        - ``status``: ``"success"`` or ``"error"``
+        - ``kernel_stats``: Full per-kernel statistics
+        - ``top_kernels``: Top *n* kernels by total duration
+        - ``category_breakdown``: Time aggregated by trace category
+        - ``pipeline_breakdown``: Time aggregated by functional pipeline
+        - ``summary``: Total traced time, unique operation count, etc.
+    """
+    try:
+        stats = extract_kernel_stats(trace_json)
+
+        if not stats:
+            return {
+                "status": "error",
+                "message": "No complete-duration events found in trace",
+            }
+
+        filtered_stats = _filter_by_category(stats, category)
+        top_kernels = get_top_kernels(filtered_stats, n=top_n)
+        category_bkdn = get_category_breakdown(stats)
+        pipeline_bkdn = get_pipeline_breakdown(stats)
+
+        total_time = sum(d["total_dur"] for d in stats.values())
+        filtered_time = sum(d["total_dur"] for d in filtered_stats.values())
+
+        return {
+            "status": "success",
+            "kernel_stats": stats,
+            "top_kernels": top_kernels,
+            "category_breakdown": category_bkdn,
+            "pipeline_breakdown": pipeline_bkdn,
+            "summary": {
+                "total_traced_time_us": total_time,
+                "total_traced_time_human": _format_duration(total_time),
+                "filtered_time_us": filtered_time,
+                "filtered_time_human": _format_duration(filtered_time),
+                "unique_operations": len(stats),
+                "filtered_operations": len(filtered_stats),
+                "category_filter": category or "all",
+            },
+        }
+
+    except Exception as exc:
+        return {"status": "error", "message": f"Failed to analyze trace: {exc}"}

--- a/auto_tune_vllm/agent/analysis/vllm_log_parser.py
+++ b/auto_tune_vllm/agent/analysis/vllm_log_parser.py
@@ -1,0 +1,248 @@
+"""
+vLLM Server Log Parser
+
+Parses raw vLLM server log text into structured sections using regex patterns.
+Extracts engine configuration, compilation settings, memory allocation, timing
+information, and warnings/errors.
+
+SOURCE: AI-Analysis-Agent/psap-mcp-server/psap_mcp_server/src/tools/vllm_log_tool.py
+Converted to sync, no S3/MCP/async dependencies.
+
+Public API:
+    parse_vllm_log(raw: str) -> dict
+        Parse raw vLLM log text into structured sections.
+"""
+
+import re
+from typing import Any, Dict, Optional
+
+
+def _safe_float(text: str) -> Optional[float]:
+    try:
+        return float(text)
+    except (ValueError, TypeError):
+        return None
+
+
+def _safe_int(text: str) -> Optional[int]:
+    try:
+        return int(text)
+    except (ValueError, TypeError):
+        return None
+
+
+def parse_vllm_log(raw: str) -> Dict[str, Any]:
+    """Parse a vLLM server log into structured sections.
+
+    Extracts configuration, compilation, memory, and timing information
+    using regex patterns matched against known vLLM log output formats.
+
+    Args:
+        raw: Raw log text (e.g. from ``cat /tmp/vllm*.log`` or process stdout).
+
+    Returns:
+        Dict with keys: server_config, engine_config, compilation, memory,
+        timing, warnings_errors. Empty sections are omitted.
+    """
+    result: Dict[str, Any] = {
+        "server_config": {},
+        "engine_config": {},
+        "compilation": {},
+        "memory": {},
+        "timing": {},
+        "warnings_errors": [],
+    }
+
+    lines = raw.splitlines()
+
+    for line in lines:
+        # --- Server config ---
+        m = re.search(r"vLLM API server version (\S+)", line)
+        if m:
+            result["server_config"]["vllm_version"] = m.group(1)
+
+        m = re.search(r"non-default args:\s*(\{.+\})", line)
+        if m:
+            try:
+                import ast
+
+                args = ast.literal_eval(m.group(1))
+                result["server_config"]["non_default_args"] = args
+                for key in (
+                    "model",
+                    "max_model_len",
+                    "gpu_memory_utilization",
+                    "enable_prefix_caching",
+                    "trust_remote_code",
+                    "port",
+                    "max_num_seqs",
+                    "max_num_batched_tokens",
+                    "enable_chunked_prefill",
+                    "enforce_eager",
+                    "tensor_parallel_size",
+                    "quantization",
+                    "scheduling_policy",
+                ):
+                    if key in args:
+                        result["server_config"][key] = args[key]
+            except Exception:
+                result["server_config"]["non_default_args_raw"] = m.group(1)
+
+        # --- Architecture ---
+        m = re.search(r"Resolved architecture:\s*(\S+)", line)
+        if m:
+            result["engine_config"]["architecture"] = m.group(1)
+
+        # --- Engine config from init log line ---
+        if (
+            "Initializing a V1 LLM engine" in line
+            or "Initializing an LLM engine" in line
+        ):
+            for field, pattern in [
+                ("dtype", r"dtype=(\S+?)(?:,|$)"),
+                ("quantization", r"quantization=(\S+?)(?:,|$)"),
+                ("tensor_parallel_size", r"tensor_parallel_size=(\d+)"),
+                ("pipeline_parallel_size", r"pipeline_parallel_size=(\d+)"),
+                ("data_parallel_size", r"data_parallel_size=(\d+)"),
+                ("max_seq_len", r"max_seq_len=(\d+)"),
+                ("enforce_eager", r"enforce_eager=(\S+?)(?:,|$)"),
+                ("enable_prefix_caching", r"enable_prefix_caching=(\S+?)(?:,|$)"),
+                ("enable_chunked_prefill", r"enable_chunked_prefill=(\S+?)(?:,|$)"),
+                ("load_format", r"load_format=(\S+?)(?:,|$)"),
+                ("kv_cache_dtype", r"kv_cache_dtype=(\S+?)(?:,|$)"),
+            ]:
+                em = re.search(pattern, line)
+                if em:
+                    val = em.group(1)
+                    if val.isdigit():
+                        result["engine_config"][field] = int(val)
+                    elif val in ("True", "False"):
+                        result["engine_config"][field] = val == "True"
+                    else:
+                        result["engine_config"][field] = val
+
+            # CUDA graph mode
+            em = re.search(r"cudagraph_mode=<CUDAGraphMode\.(\S+?):", line)
+            if em:
+                result["engine_config"]["cudagraph_mode"] = em.group(1)
+
+            # Max cudagraph capture size
+            em = re.search(r"max_cudagraph_capture_size['\"]?:\s*(\d+)", line)
+            if em:
+                result["engine_config"]["max_cudagraph_capture_size"] = int(em.group(1))
+
+            # Count cudagraph capture sizes
+            em = re.search(r"cudagraph_capture_sizes['\"]?:\s*\[([^\]]+)\]", line)
+            if em:
+                sizes = [s.strip() for s in em.group(1).split(",") if s.strip()]
+                result["engine_config"]["num_cudagraph_capture_sizes"] = len(sizes)
+
+        # --- Chunked prefill ---
+        m = re.search(
+            r"Chunked prefill is enabled with max_num_batched_tokens=(\d+)", line
+        )
+        if m:
+            result["engine_config"]["chunked_prefill"] = True
+            result["engine_config"]["max_num_batched_tokens"] = int(m.group(1))
+
+        m = re.search(r"Overriding max cuda graph capture size to (\d+)", line)
+        if m:
+            result["engine_config"]["max_cudagraph_capture_size_override"] = int(
+                m.group(1)
+            )
+
+        # --- Attention backend ---
+        m = re.search(r"Using (\S+) attention backend", line)
+        if m:
+            result["compilation"]["attention_backend"] = m.group(1)
+
+        # --- MoE stream ---
+        if "separate cuda stream for MoE shared_experts" in line:
+            result["compilation"]["moe_shared_experts_stream"] = True
+
+        # --- Quantization backend ---
+        m = re.search(r"\[mxfp4\.py:\d+\]\s*Using (\S+) backend", line)
+        if m:
+            result["compilation"]["quantization_backend"] = m.group(1)
+
+        # --- Model loading ---
+        m = re.search(r"Loading weights took (\S+) seconds", line)
+        if m:
+            result["memory"]["weights_load_time_s"] = _safe_float(m.group(1))
+
+        m = re.search(r"Model loading took (\S+) GiB memory and (\S+) seconds", line)
+        if m:
+            result["memory"]["model_memory_gib"] = _safe_float(m.group(1))
+            result["memory"]["model_load_time_s"] = _safe_float(m.group(2))
+
+        # --- torch.compile ---
+        m = re.search(r"Dynamo bytecode transform time:\s*(\S+)\s*s", line)
+        if m:
+            result["compilation"]["dynamo_transform_time_s"] = _safe_float(m.group(1))
+
+        m = re.search(r"Compiling a graph .+ takes (\S+)\s*s", line)
+        if m:
+            result["compilation"]["graph_compile_time_s"] = _safe_float(m.group(1))
+
+        m = re.search(r"torch\.compile takes (\S+)\s*s in total", line)
+        if m:
+            result["compilation"]["torch_compile_time_s"] = _safe_float(m.group(1))
+
+        # --- KV cache ---
+        m = re.search(r"Available KV cache memory:\s*(\S+)\s*GiB", line)
+        if m:
+            result["memory"]["kv_cache_memory_gib"] = _safe_float(m.group(1))
+
+        m = re.search(r"GPU KV cache size:\s*([\d,]+)\s*tokens", line)
+        if m:
+            result["memory"]["kv_cache_tokens"] = _safe_int(m.group(1).replace(",", ""))
+
+        m = re.search(r"Maximum concurrency for .+ per request:\s*(\S+)x", line)
+        if m:
+            result["memory"]["max_concurrency"] = _safe_float(m.group(1))
+
+        # --- CUDA graph capture ---
+        m = re.search(
+            r"Graph capturing finished in (\d+)\s*secs?, took (\S+)\s*GiB", line
+        )
+        if m:
+            result["compilation"]["cuda_graph_capture_time_s"] = _safe_int(m.group(1))
+            result["compilation"]["cuda_graph_memory_gib"] = _safe_float(m.group(2))
+
+        # --- Engine init ---
+        m = re.search(r"init engine .+ took (\S+) seconds", line)
+        if m:
+            result["timing"]["engine_init_time_s"] = _safe_float(m.group(1))
+
+        # --- TP/PP rank info ---
+        m = re.search(r"world_size=(\d+)\s+rank=(\d+)", line)
+        if m:
+            result["engine_config"]["world_size"] = int(m.group(1))
+
+        m = re.search(r"TP rank (\d+), EP rank (\d+)", line)
+        if m:
+            result["engine_config"]["tp_rank"] = int(m.group(1))
+            result["engine_config"]["ep_rank"] = int(m.group(2))
+
+        # --- Serving info ---
+        m = re.search(r"Uvicorn running on (\S+)", line)
+        if m:
+            result["server_config"]["uvicorn_url"] = m.group(1)
+
+        m = re.search(r"Starting vLLM API server on (\S+):(\d+)", line)
+        if m:
+            result["server_config"]["host"] = m.group(1)
+            result["server_config"]["port"] = int(m.group(2))
+
+        # --- Warnings and errors ---
+        if "WARNING" in line or "ERROR" in line:
+            cleaned = line.strip()
+            if (
+                cleaned
+                and "Loading safetensors" not in cleaned
+                and "Capturing CUDA" not in cleaned
+            ):
+                result["warnings_errors"].append(cleaned)
+
+    # Remove empty sections
+    return {k: v for k, v in result.items() if v}

--- a/auto_tune_vllm/agent/llm.py
+++ b/auto_tune_vllm/agent/llm.py
@@ -1,0 +1,237 @@
+"""
+LLM wrapper with token tracking for Claude API (direct Anthropic and Vertex AI).
+"""
+
+import os
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+import anthropic
+from anthropic import AnthropicVertex
+
+# Pricing per 1M tokens (USD)
+MODEL_PRICING = {
+    "claude-sonnet-4-20250514": {"input": 3.0, "output": 15.0},
+    "claude-opus-4-20250514": {"input": 15.0, "output": 75.0},
+    "claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.0},
+}
+
+
+def to_vertex_model_id(model_id: str) -> str:
+    """Convert a standard Anthropic model ID to Vertex AI format.
+
+    Vertex AI uses '@' instead of the last '-' before the date stamp.
+    e.g. "claude-sonnet-4-20250514" -> "claude-sonnet-4@20250514"
+         "claude-opus-4-20250514"   -> "claude-opus-4@20250514"
+         "claude-haiku-4-5-20251001" -> "claude-haiku-4-5@20251001"
+    If the model already contains '@', return as-is.
+    """
+    if "@" in model_id:
+        return model_id
+    # Match the last '-' followed by a pure-digit date suffix
+    match = re.match(r"^(.+)-(\d{8,})$", model_id)
+    if match:
+        return f"{match.group(1)}@{match.group(2)}"
+    return model_id
+
+
+@dataclass
+class TokenUsage:
+    """Track token usage per model."""
+
+    model: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    calls: int = 0
+
+    def add(
+        self,
+        input_tokens: int,
+        output_tokens: int,
+        cache_read_tokens: int = 0,
+        cache_creation_tokens: int = 0,
+    ):
+        self.input_tokens += input_tokens
+        self.output_tokens += output_tokens
+        self.cache_read_tokens += cache_read_tokens
+        self.cache_creation_tokens += cache_creation_tokens
+        self.calls += 1
+
+    def cost(self) -> float:
+        """Calculate cost in USD (accounts for cache discount)."""
+        pricing = MODEL_PRICING.get(self.model, {"input": 3.0, "output": 15.0})
+        # Cache read tokens cost 90% less, cache creation costs 25% more
+        regular_input = (
+            self.input_tokens - self.cache_read_tokens - self.cache_creation_tokens
+        )
+        input_cost = (regular_input / 1_000_000) * pricing["input"]
+        cache_read_cost = (self.cache_read_tokens / 1_000_000) * pricing["input"] * 0.1
+        cache_create_cost = (
+            (self.cache_creation_tokens / 1_000_000) * pricing["input"] * 1.25
+        )
+        output_cost = (self.output_tokens / 1_000_000) * pricing["output"]
+        return input_cost + cache_read_cost + cache_create_cost + output_cost
+
+    def to_dict(self) -> dict:
+        return {
+            "model": self.model,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "cache_creation_tokens": self.cache_creation_tokens,
+            "total_tokens": self.input_tokens + self.output_tokens,
+            "api_calls": self.calls,
+            "cost_usd": round(self.cost(), 4),
+        }
+
+
+@dataclass
+class LLMResponse:
+    """Response from LLM with content and token info."""
+
+    content: str
+    input_tokens: int
+    output_tokens: int
+    model: str
+
+
+# Available models
+MODELS = {
+    "sonnet": "claude-sonnet-4-20250514",
+    "opus": "claude-opus-4-20250514",
+    "haiku": "claude-haiku-4-5-20251001",
+}
+
+
+def get_model_id(model_name: str) -> str:
+    """Convert short model name to full model ID."""
+    if model_name in MODELS:
+        return MODELS[model_name]
+    return model_name
+
+
+class ClaudeClient:
+    """Claude API client with token tracking (direct Anthropic API or Vertex AI)."""
+
+    DEFAULT_MODEL = "claude-sonnet-4-20250514"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        use_vertex: bool = False,
+        vertex_project_id: Optional[str] = None,
+        vertex_region: str = "us-east5",
+    ):
+        self.use_vertex = use_vertex
+        self.model = model or self.DEFAULT_MODEL
+        self.usage: dict[str, TokenUsage] = {}
+
+        if self.use_vertex:
+            project_id = vertex_project_id or os.environ.get(
+                "ANTHROPIC_VERTEX_PROJECT_ID"
+            )
+            if not project_id:
+                raise ValueError(
+                    "Vertex AI requires a project ID. "
+                    "Set --vertex-project-id or ANTHROPIC_VERTEX_PROJECT_ID."
+                )
+            region = vertex_region or os.environ.get("CLOUD_ML_REGION", "us-east5")
+            self.client = AnthropicVertex(
+                project_id=project_id,
+                region=region,
+            )
+            # Convert model ID to Vertex format (uses '@' separator)
+            self.model = to_vertex_model_id(self.model)
+        else:
+            self.client = anthropic.Anthropic(api_key=api_key)
+
+    def _get_usage(self, model: str) -> TokenUsage:
+        if model not in self.usage:
+            self.usage[model] = TokenUsage(model=model)
+        return self.usage[model]
+
+    def analyze(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: Optional[str] = None,
+        max_tokens: int = 4096,
+    ) -> LLMResponse:
+        """Send a prompt to Claude and track token usage."""
+        model = model or self.model
+
+        response = self.client.messages.create(
+            model=model,
+            max_tokens=max_tokens,
+            system=system_prompt,
+            messages=[{"role": "user", "content": user_prompt}],
+        )
+
+        input_tokens = response.usage.input_tokens
+        output_tokens = response.usage.output_tokens
+
+        # Track usage
+        self._get_usage(model).add(input_tokens, output_tokens)
+
+        content = response.content[0].text if response.content else ""
+
+        return LLMResponse(
+            content=content,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            model=model,
+        )
+
+    def get_total_usage(self) -> list[dict]:
+        """Get token usage summary for all models."""
+        return [usage.to_dict() for usage in self.usage.values()]
+
+    def get_usage_data(self) -> list:
+        """Return token usage as a list of dicts for structured reporting."""
+        data = []
+        for usage in self.usage.values():
+            data.append(
+                {
+                    "model": usage.model,
+                    "input_tokens": usage.input_tokens,
+                    "output_tokens": usage.output_tokens,
+                    "cache_read_tokens": usage.cache_read_tokens,
+                    "cache_creation_tokens": usage.cache_creation_tokens,
+                    "api_calls": usage.calls,
+                    "cost_usd": usage.cost(),
+                }
+            )
+        return data
+
+    def get_usage_report(self) -> str:
+        """Generate a markdown table of token usage with cost."""
+        lines = [
+            "| Model | Input Tokens | Output Tokens | Total | API Calls | Cost (USD) |",
+            "|-------|--------------|---------------|-------|-----------|------------|",
+        ]
+
+        total_input = 0
+        total_output = 0
+        total_calls = 0
+        total_cost = 0.0
+
+        for usage in self.usage.values():
+            total = usage.input_tokens + usage.output_tokens
+            cost = usage.cost()
+            lines.append(
+                f"| {usage.model} | {usage.input_tokens:,} | {usage.output_tokens:,} | {total:,} | {usage.calls} | ${cost:.4f} |"
+            )
+            total_input += usage.input_tokens
+            total_output += usage.output_tokens
+            total_calls += usage.calls
+            total_cost += cost
+
+        lines.append(
+            f"| **Total** | **{total_input:,}** | **{total_output:,}** | **{total_input + total_output:,}** | **{total_calls}** | **${total_cost:.4f}** |"
+        )
+
+        return "\n".join(lines)

--- a/auto_tune_vllm/agent/main.py
+++ b/auto_tune_vllm/agent/main.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""
+vLLM Performance Tuning Agent - CLI Entry Point
+"""
+
+import argparse
+import atexit
+import json
+import os
+import sys
+
+from .agentic import AgenticRunner
+from .llm import ClaudeClient, get_model_id
+from .pod_manager import PodManager
+from .reporter import Reporter, TuningReport
+from .ssh_client import SSHClient
+from .tools import PROFILE_CHOICES, AgentTools, OcExecutor, SSHExecutor
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create argument parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Agentic vLLM tuner — Claude benchmarks a baseline server, "
+            "spins up experiment pods with new args, and reports regressions."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # OpenShift pod-per-experiment (recommended)
+  auto-tune-vllm agent \\
+      --vllm-endpoint http://localhost:8000 \\
+      --model facebook/opt-125m \\
+      --oc-mode --oc-pod vllm-baseline --oc-namespace llm-d \\
+      --pod-template examples/agent/experiment-pod.yaml
+
+  # SSH mode against a GPU host
+  python -m auto_tune_vllm.agent \\
+      --vllm-endpoint http://gpu:8000 \\
+      --vllm-host gpu-node \\
+      --model meta-llama/Llama-3.1-8B \\
+      --api-key $ANTHROPIC_API_KEY
+
+Available Claude models: sonnet (default), opus, haiku
+        """,
+    )
+
+    parser.add_argument(
+        "--vllm-endpoint",
+        required=True,
+        help="URL of the vLLM server (e.g. http://gpu:8000)",
+    )
+    parser.add_argument(
+        "--vllm-host",
+        default=None,
+        help="SSH hostname for the GPU node running vLLM (required for SSH mode)",
+    )
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="Model served by vLLM (e.g. meta-llama/Llama-3.1-8B)",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("ANTHROPIC_API_KEY"),
+        help="Anthropic API key (default: $ANTHROPIC_API_KEY)",
+    )
+    parser.add_argument(
+        "--claude-model",
+        default="sonnet",
+        help="Claude model for the agent (sonnet, opus, haiku, or full ID). Default: sonnet",
+    )
+    parser.add_argument(
+        "--max-iterations",
+        type=int,
+        default=100,
+        help="Max agent loop iterations (default: 100)",
+    )
+    parser.add_argument(
+        "--profiles",
+        nargs="+",
+        default=["balanced"],
+        choices=PROFILE_CHOICES,
+        help="Benchmark profiles to run (default: balanced)",
+    )
+    parser.add_argument(
+        "--ssh-user", default="root", help="SSH user for vLLM host (default: root)"
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default="agent_reports",
+        help="Output directory for reports (default: agent_reports/)",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+
+    # Execution mode: SSH or oc exec
+    parser.add_argument(
+        "--oc-mode",
+        action="store_true",
+        default=False,
+        help="Use 'oc exec' instead of SSH to reach the vLLM pod",
+    )
+    parser.add_argument(
+        "--oc-namespace",
+        default=None,
+        help="OpenShift namespace for oc exec (required with --oc-mode)",
+    )
+    parser.add_argument(
+        "--oc-pod", default=None, help="Pod name for oc exec (required if --oc-mode)"
+    )
+    parser.add_argument(
+        "--kubeconfig",
+        default=os.environ.get("KUBECONFIG"),
+        help="Path to kubeconfig file (default: $KUBECONFIG)",
+    )
+    parser.add_argument(
+        "--pod-template",
+        default=None,
+        help=(
+            "Path to a pod YAML template for creating experiment pods "
+            "(see examples/agent/experiment-pod.yaml). Enables "
+            "create_vllm_pod/delete_vllm_pod. Requires --oc-mode."
+        ),
+    )
+
+    # Vertex AI options
+    parser.add_argument(
+        "--vertex",
+        action="store_true",
+        default=os.environ.get("CLAUDE_CODE_USE_VERTEX", "0") == "1",
+        help="Use Google Cloud Vertex AI for Claude API access (default: true if CLAUDE_CODE_USE_VERTEX=1)",
+    )
+    parser.add_argument(
+        "--vertex-project-id",
+        default=os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID"),
+        help="Vertex AI project ID (default: $ANTHROPIC_VERTEX_PROJECT_ID)",
+    )
+    parser.add_argument(
+        "--vertex-region",
+        default=os.environ.get("CLOUD_ML_REGION", "us-east5"),
+        help="Vertex AI region (default: $CLOUD_ML_REGION or us-east5)",
+    )
+
+    return parser
+
+
+def print_header(msg: str):
+    """Print a section header."""
+    print(f"\n{'=' * 60}", flush=True)
+    print(f"  {msg}", flush=True)
+    print(f"{'=' * 60}\n", flush=True)
+
+
+def print_step(msg: str):
+    """Print a step message."""
+    print(f">> {msg}", flush=True)
+
+
+def run_agent(args) -> None:
+    """Run the agent loop from a parsed argparse namespace (or equivalent)."""
+
+    # Validate API key (only required when NOT using Vertex AI)
+    if not args.vertex and not args.api_key:
+        print(
+            "Error: ANTHROPIC_API_KEY not set. Use --api-key or set the environment variable."
+        )
+        print("       Alternatively, use --vertex for Google Cloud Vertex AI access.")
+        sys.exit(1)
+
+    if args.vertex and not args.vertex_project_id:
+        print(
+            "Error: Vertex AI project ID not set. Use --vertex-project-id or set ANTHROPIC_VERTEX_PROJECT_ID."
+        )
+        sys.exit(1)
+
+    # Determine backend label
+    backend = "Vertex AI" if args.vertex else "Direct API"
+
+    # Print banner
+    print_header("auto-tune-vllm agentic tuner")
+    print(f"vLLM Endpoint:  {args.vllm_endpoint}")
+    print(f"vLLM Host:      {args.vllm_host}")
+    print(f"Served Model:   {args.model}")
+    print(f"Claude Model:   {get_model_id(args.claude_model)}")
+    print(f"Claude Backend: {backend}")
+    if args.vertex:
+        print(f"Vertex Project: {args.vertex_project_id}")
+        print(f"Vertex Region:  {args.vertex_region}")
+    print(f"Max Iterations: {args.max_iterations}")
+    print(f"Profiles:       {', '.join(args.profiles)}")
+    print(f"Output Dir:     {args.output}")
+
+    # Validate mode-specific args
+    if not args.oc_mode and not args.vllm_host:
+        print(
+            "Error: --vllm-host is required for SSH mode. Use --oc-mode for OpenShift."
+        )
+        sys.exit(1)
+
+    # Set up remote executor (SSH or oc exec)
+    if args.oc_mode:
+        if not args.oc_pod:
+            print("Error: --oc-pod is required when using --oc-mode")
+            sys.exit(1)
+        if not args.oc_namespace:
+            print("Error: --oc-namespace is required when using --oc-mode")
+            sys.exit(1)
+        print_step(f"Using oc exec mode: {args.oc_namespace}/{args.oc_pod}")
+        executor = OcExecutor(
+            namespace=args.oc_namespace,
+            pod_name=args.oc_pod,
+            kubeconfig=args.kubeconfig,
+        )
+        # Test connectivity
+        test_result = executor.run("echo OK")
+        if not test_result.success:
+            print(f"Error: Cannot connect to pod: {test_result.stderr}")
+            sys.exit(1)
+        print(f"  oc exec to {args.oc_pod}: OK")
+    else:
+        print_step("Testing SSH connectivity to vLLM host...")
+        ssh = SSHClient(args.vllm_host, user=args.ssh_user)
+        if not ssh.test_connection():
+            print(f"Error: Cannot connect to vLLM host ({args.vllm_host})")
+            sys.exit(1)
+        print(f"  SSH to {args.vllm_host}: OK")
+        executor = SSHExecutor(ssh)
+
+    # Test Claude API connectivity
+    print_step(f"Testing Claude API connectivity ({backend})...")
+    llm = ClaudeClient(
+        api_key=args.api_key,
+        model=get_model_id(args.claude_model),
+        use_vertex=args.vertex,
+        vertex_project_id=args.vertex_project_id,
+        vertex_region=args.vertex_region,
+    )
+    try:
+        test_response = llm.analyze(
+            system_prompt="You are a test assistant.",
+            user_prompt="Reply with exactly: API_OK",
+            max_tokens=16,
+        )
+        if "API_OK" in test_response.content:
+            print(f"  Claude API: OK (model: {test_response.model})")
+        else:
+            print(f"  Claude API: Connected (model: {test_response.model})")
+    except Exception as e:
+        print(f"Error: Claude API connection failed: {e}")
+        sys.exit(1)
+
+    # Print token usage from connectivity test
+    print_step("Connectivity verified. Ready to run agent loop.")
+    print("\n  Token usage so far:")
+    print(f"  {llm.get_usage_report()}")
+
+    # Create PodManager if --pod-template is provided
+    pod_manager = None
+    if args.pod_template:
+        if not args.oc_mode:
+            print("Error: --pod-template requires --oc-mode")
+            sys.exit(1)
+        print_step(f"Initializing PodManager with template: {args.pod_template}")
+        pod_manager = PodManager(
+            namespace=args.oc_namespace,
+            kubeconfig=args.kubeconfig,
+            base_pod_yaml_path=args.pod_template,
+        )
+        # Register cleanup to delete leftover experiment pods on exit
+        atexit.register(pod_manager.cleanup_all)
+        print(f"  PodManager ready (namespace={args.oc_namespace})")
+
+    # Create tools and agent
+    tools = AgentTools(
+        executor=executor,
+        vllm_endpoint=args.vllm_endpoint,
+        model_name=args.model,
+        pod_manager=pod_manager,
+        namespace=args.oc_namespace if args.oc_mode else None,
+        kubeconfig=args.kubeconfig,
+    )
+
+    agent = AgenticRunner(
+        llm_client=llm,
+        tools=tools,
+        max_iterations=args.max_iterations,
+        vllm_endpoint=args.vllm_endpoint,
+        model_name=args.model,
+        profiles=args.profiles,
+    )
+
+    # Run the agent loop
+    print_step("Starting agent loop...")
+    try:
+        state = agent.run()
+    finally:
+        # Ensure experiment pods are cleaned up even on exceptions
+        if pod_manager:
+            pod_manager.cleanup_all()
+
+    # Generate report
+    print_step("Generating report...")
+    from datetime import datetime, timezone
+
+    # Extract GPU info and actions from command history
+    gpu_info = ""
+    actions = list(state.actions_taken)
+    for entry in tools.command_history:
+        out = entry.get("output", "")
+        cmd = entry.get("command", "")
+        if entry.get("tool") == "run_command" and "nvidia-smi" in cmd and out:
+            # Pull GPU name from nvidia-smi output
+            for line in out.split("\n"):
+                if "NVIDIA" in line and (
+                    "H100" in line or "H200" in line or "A100" in line or "GPU" in line
+                ):
+                    gpu_info = line.strip()
+                    break
+        if entry.get("tool") == "run_command" and entry.get("success"):
+            actions.append(
+                {
+                    "type": "run_command",
+                    "command": cmd[:80],
+                    "timestamp": "",
+                }
+            )
+
+    # Build summary from agent messages if the agent didn't call done
+    summary = state.summary
+    if summary == "Max iterations reached without completion.":
+        # Pull the last agent message as a summary
+        for msg in reversed(agent.messages):
+            if msg.get("role") == "assistant":
+                content = msg.get("content", "")
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            summary = block["text"][:500]
+                            break
+                        elif hasattr(block, "type") and block.type == "text":
+                            summary = block.text[:500]
+                            break
+                elif isinstance(content, str) and content:
+                    summary = content[:500]
+                if summary != "Max iterations reached without completion.":
+                    break
+
+    # Build structured baseline/final results for the report.
+    # AgentState stores raw benchmark output per profile; convert to dicts
+    # that the reporter can use for before/after comparison.
+    #
+    # The raw output contains embedded JSON blocks from _extract_flat_metrics
+    # with keys like "output_tok/sec_mean", "ttft_p50", "itl_p50", etc.
+    # We parse those JSON blocks to get accurate numbers.
+    def _parse_benchmark_output(results_dict: dict) -> list[dict]:
+        """Extract structured metrics from stored benchmark output per profile.
+
+        The output comes from run_benchmark which uses _extract_guidellm_metrics.
+        It contains human-readable lines like:
+          Output Tokens/sec: mean=627.16, median=784.57, p50=784.57, p95=868.80
+          TTFT (ms): mean=42.36, median=31.53, p50=31.53, p95=116.69, p99=120.46
+
+        We also check for embedded JSON blocks (from read_benchmark_results
+        flat metrics output) as a fallback.
+        """
+        import re
+
+        parsed = []
+        for profile, raw_output in results_dict.items():
+            entry = {"profile": profile}
+            if isinstance(raw_output, str):
+                # Strategy 1: Parse human-readable metric lines from
+                # _extract_guidellm_metrics output.  We want the LAST
+                # concurrency block (highest concurrency) for reporting.
+                # Split by concurrency blocks and use the last one
+                blocks = re.split(r"--- Concurrency: \d+", raw_output)
+                text_block = blocks[-1] if len(blocks) > 1 else raw_output
+
+                # Extract key=value pairs from metric lines
+                def _extract_kv(line):
+                    """Parse 'mean=1.23, median=4.56, p50=7.89' into dict."""
+                    return dict(re.findall(r"(\w+)=([\d.]+)", line))
+
+                for line in text_block.split("\n"):
+                    line_stripped = line.strip()
+                    if line_stripped.startswith("Output Tokens/sec:"):
+                        kv = _extract_kv(line_stripped)
+                        if "mean" in kv and "throughput_tok_per_sec" not in entry:
+                            entry["throughput_tok_per_sec"] = float(kv["mean"])
+                    elif line_stripped.startswith("TTFT (ms):"):
+                        kv = _extract_kv(line_stripped)
+                        for p in ("p50", "p95", "p99"):
+                            if p in kv and f"ttft_{p}" not in entry:
+                                entry[f"ttft_{p}"] = float(kv[p])
+                    elif line_stripped.startswith("ITL (ms):"):
+                        kv = _extract_kv(line_stripped)
+                        for p in ("p50", "p95", "p99"):
+                            if p in kv and f"itl_{p}" not in entry:
+                                entry[f"itl_{p}"] = float(kv[p])
+                    elif line_stripped.startswith("TPOT (ms):"):
+                        kv = _extract_kv(line_stripped)
+                        for p in ("p50", "p95", "p99"):
+                            if p in kv and f"tpot_{p}" not in entry:
+                                entry[f"tpot_{p}"] = float(kv[p])
+
+                # Strategy 2: Fallback — look for embedded JSON blocks
+                # (from read_benchmark_results flat metrics output)
+                if "throughput_tok_per_sec" not in entry:
+                    best_metrics = {}
+                    for m in re.finditer(r"\{[^{}]+\}", raw_output):
+                        try:
+                            obj = json.loads(m.group())
+                            if obj.get("concurrency", 0) >= best_metrics.get(
+                                "concurrency", 0
+                            ):
+                                best_metrics = obj
+                        except (json.JSONDecodeError, ValueError):
+                            continue
+                    if best_metrics:
+                        key_map = {
+                            "output_tok/sec_mean": "throughput_tok_per_sec",
+                            "ttft_p50": "ttft_p50",
+                            "ttft_p95": "ttft_p95",
+                            "ttft_p99": "ttft_p99",
+                            "itl_p50": "itl_p50",
+                            "itl_p95": "itl_p95",
+                            "itl_p99": "itl_p99",
+                            "tpot_p50": "tpot_p50",
+                            "tpot_p95": "tpot_p95",
+                            "tpot_p99": "tpot_p99",
+                        }
+                        for src, dst in key_map.items():
+                            v = best_metrics.get(src)
+                            if v is not None and dst not in entry:
+                                entry[dst] = float(v)
+
+            parsed.append(entry)
+        return parsed
+
+    baseline_results = _parse_benchmark_output(state.baseline_results)
+    final_results = _parse_benchmark_output(state.current_results)
+
+    # Fallback: if baseline or final results are missing metrics, try to
+    # extract them from the decision log.  The decision log records the
+    # output of every tool call (truncated to 4000 chars) and is always
+    # available.  This handles cases where state.baseline_results was not
+    # populated correctly despite the benchmark succeeding.
+    decision_log = agent.get_decision_log()
+
+    def _has_metrics(entry: dict) -> bool:
+        return "throughput_tok_per_sec" in entry
+
+    def _extract_from_decision_log(
+        decision_log: list,
+        vllm_endpoint: str,
+        is_baseline: bool,
+    ) -> list[dict]:
+        """Parse benchmark outputs from the decision log.
+
+        For baseline: pick run_benchmark calls whose endpoint matches the
+        CLI endpoint (or has no explicit endpoint).
+        For final/experiment: pick run_benchmark calls with a different
+        endpoint.
+        """
+        profile_outputs: dict[str, str] = {}
+        for entry in decision_log:
+            if entry.get("tool") != "run_benchmark":
+                continue
+            output = entry.get("output", "")
+            if not output or output.startswith("Error:"):
+                continue
+            if "Tokens/sec" not in output:
+                continue
+            inputs = entry.get("inputs", {})
+            ep = inputs.get("endpoint", vllm_endpoint)
+            entry_is_baseline = ep == vllm_endpoint
+            if entry_is_baseline != is_baseline:
+                continue
+            profile = inputs.get("profile", "unknown")
+            # Keep the LAST successful benchmark for each profile
+            profile_outputs[profile] = output
+        return _parse_benchmark_output(profile_outputs)
+
+    # Fill in missing baseline metrics from decision log
+    if all(not _has_metrics(e) for e in baseline_results) and decision_log:
+        fallback = _extract_from_decision_log(
+            decision_log, args.vllm_endpoint, is_baseline=True
+        )
+        if fallback and any(_has_metrics(e) for e in fallback):
+            baseline_results = fallback
+
+    # Fill in missing final metrics from decision log
+    if all(not _has_metrics(e) for e in final_results) and decision_log:
+        fallback = _extract_from_decision_log(
+            decision_log, args.vllm_endpoint, is_baseline=False
+        )
+        if fallback and any(_has_metrics(e) for e in fallback):
+            final_results = fallback
+
+    report = TuningReport(
+        timestamp=datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S"),
+        model_name=args.model,
+        vllm_endpoint=args.vllm_endpoint,
+        gpu_info=gpu_info,
+        agent_summary=summary,
+        baseline_results=baseline_results,
+        final_results=final_results,
+        actions_taken=actions,
+        kernel_analysis=state.kernel_analysis,
+        token_usage=llm.get_usage_data(),
+        decision_log=agent.get_decision_log(),
+    )
+
+    reporter = Reporter(output_dir=args.output)
+    md_path, json_path = reporter.generate(report)
+    print(f"  Markdown report: {md_path}")
+    print(f"  JSON report:     {json_path}")
+
+    # Final summary
+    print_header("Agent Complete")
+    print(f"  Success: {state.success}")
+    print(f"  Iterations: {state.iteration}")
+    print(f"  Summary: {state.summary[:200]}")
+    print("\n  Token usage:")
+    print(f"  {llm.get_usage_report()}")
+
+
+def main():
+    """CLI entry point for ``python -m auto_tune_vllm.agent``."""
+    parser = create_parser()
+    args = parser.parse_args()
+    run_agent(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/auto_tune_vllm/agent/pod_manager.py
+++ b/auto_tune_vllm/agent/pod_manager.py
@@ -1,0 +1,315 @@
+"""
+Pod Manager for Isolated Pod-per-Experiment Architecture.
+
+Creates ephemeral vLLM pods from a YAML template for each tuning experiment.
+The baseline pod is never modified; experiment pods are created with different
+vLLM launch args, benchmarked, compared against baseline, then deleted.
+
+Usage:
+    pm = PodManager(namespace="llm-d", kubeconfig=None, base_pod_yaml_path="examples/agent/experiment-pod.yaml")
+    pod_name, endpoint = pm.create_pod(["--enable-chunked-prefill", "--gpu-memory-utilization", "0.95"])
+    # ... run benchmarks against endpoint ...
+    pm.delete_pod(pod_name)
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import signal
+import subprocess
+import tempfile
+import time
+from typing import Optional
+
+import yaml
+
+
+class PodManager:
+    """Manages ephemeral vLLM experiment pods on OpenShift.
+
+    Creates pods from a YAML template with modified vLLM args, waits for
+    readiness, sets up port-forwarding, and cleans up on deletion.
+
+    Parameters
+    ----------
+    namespace : str
+        Kubernetes/OpenShift namespace.
+    kubeconfig : str or None
+        Path to kubeconfig. If None, uses default (~/.kube/config or $KUBECONFIG).
+    base_pod_yaml_path : str
+        Path to the pod YAML template (e.g. examples/agent/experiment-pod.yaml).
+    base_port : int
+        First local port to assign for port-forwarding experiment pods.
+    """
+
+    def __init__(
+        self,
+        namespace: str,
+        kubeconfig: Optional[str] = None,
+        base_pod_yaml_path: str = "examples/agent/experiment-pod.yaml",
+        base_port: int = 8001,
+    ):
+        self.namespace = namespace
+        self.kubeconfig = kubeconfig
+        self.base_yaml_path = base_pod_yaml_path
+        self.base_port = base_port
+        self.active_pods: dict[
+            str, dict
+        ] = {}  # pod_name -> {"port_forward_proc": ..., "local_port": ...}
+        self._next_port = base_port
+
+        # Load and validate the template once
+        with open(self.base_yaml_path, "r") as f:
+            self._template = yaml.safe_load(f)
+
+        if self._template.get("kind") != "Pod":
+            raise ValueError(
+                f"Template {base_pod_yaml_path} is not a Pod manifest (kind={self._template.get('kind')})"
+            )
+
+    def _build_oc_base(self) -> list[str]:
+        """Build the base ``oc`` command with kubeconfig and namespace."""
+        cmd = ["oc"]
+        if self.kubeconfig:
+            cmd += ["--kubeconfig", self.kubeconfig]
+        cmd += ["-n", self.namespace]
+        return cmd
+
+    def _generate_pod_name(self) -> str:
+        """Generate a unique pod name based on timestamp."""
+        ts = int(time.time())
+        return f"vllm-tune-{ts}"
+
+    def _build_pod_manifest(self, pod_name: str, vllm_args: list[str]) -> dict:
+        """Create a pod manifest from the template with extra vLLM args.
+
+        Appends ``vllm_args`` to the existing ``args`` list of the first
+        container (assumed to be the vLLM container).
+        """
+        manifest = copy.deepcopy(self._template)
+
+        # Set unique pod name
+        manifest["metadata"]["name"] = pod_name
+
+        # Add a label to identify experiment pods for easy cleanup
+        labels = manifest["metadata"].setdefault("labels", {})
+        labels["vllm-experiment"] = "true"
+
+        # Append tuning args to the container's args list
+        container = manifest["spec"]["containers"][0]
+        existing_args = list(container.get("args", []))
+        existing_args.extend(vllm_args)
+        container["args"] = existing_args
+
+        return manifest
+
+    def _wait_for_ready(
+        self, pod_name: str, timeout: int = 120, poll_interval: int = 5
+    ) -> bool:
+        """Poll pod readiness until ready or timeout.
+
+        Returns True if the pod reached Running + Ready state.
+        """
+        oc_base = self._build_oc_base()
+        deadline = time.time() + timeout
+
+        while time.time() < deadline:
+            # Check pod phase
+            cmd = oc_base + [
+                "get",
+                "pod",
+                pod_name,
+                "-o",
+                "jsonpath={.status.phase}",
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+            phase = result.stdout.strip()
+
+            if phase == "Failed" or phase == "Unknown":
+                # Pod failed to start — get events for debugging
+                events_cmd = oc_base + [
+                    "get",
+                    "events",
+                    "--field-selector",
+                    f"involvedObject.name={pod_name}",
+                    "--sort-by=.lastTimestamp",
+                ]
+                events_result = subprocess.run(
+                    events_cmd, capture_output=True, text=True, timeout=15
+                )
+                raise RuntimeError(
+                    f"Pod {pod_name} entered phase '{phase}'. Events:\n{events_result.stdout}"
+                )
+
+            if phase == "Running":
+                # Check readiness condition
+                ready_cmd = oc_base + [
+                    "get",
+                    "pod",
+                    pod_name,
+                    "-o",
+                    "jsonpath={.status.conditions[?(@.type=='Ready')].status}",
+                ]
+                ready_result = subprocess.run(
+                    ready_cmd, capture_output=True, text=True, timeout=15
+                )
+                if ready_result.stdout.strip() == "True":
+                    return True
+
+            time.sleep(poll_interval)
+
+        raise TimeoutError(
+            f"Pod {pod_name} not ready after {timeout}s (last phase: {phase})"
+        )
+
+    def _start_port_forward(
+        self, pod_name: str, local_port: int, remote_port: int = 8000
+    ) -> subprocess.Popen:
+        """Start ``oc port-forward`` as a background subprocess."""
+        cmd = self._build_oc_base() + [
+            "port-forward",
+            pod_name,
+            f"{local_port}:{remote_port}",
+        ]
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        # Give port-forward a moment to bind
+        time.sleep(2)
+
+        # Check it didn't immediately die
+        if proc.poll() is not None:
+            stderr = proc.stderr.read().decode() if proc.stderr else ""
+            raise RuntimeError(
+                f"oc port-forward for {pod_name} exited immediately (rc={proc.returncode}): {stderr}"
+            )
+
+        return proc
+
+    def create_pod(self, vllm_args: list[str]) -> tuple[str, str]:
+        """Create an experiment pod with extra vLLM args, wait for readiness,
+        and start port-forwarding.
+
+        Parameters
+        ----------
+        vllm_args : list[str]
+            Extra CLI args for vLLM (e.g. ["--enable-chunked-prefill",
+            "--gpu-memory-utilization", "0.95"]).
+
+        Returns
+        -------
+        tuple[str, str]
+            (pod_name, endpoint_url) e.g. ("vllm-tune-1714000000", "http://localhost:8001")
+        """
+        pod_name = self._generate_pod_name()
+        local_port = self._next_port
+        self._next_port += 1
+
+        print(
+            f">> PodManager: Creating pod {pod_name} with args {vllm_args}", flush=True
+        )
+
+        # Build manifest
+        manifest = self._build_pod_manifest(pod_name, vllm_args)
+
+        # Write to temp file and apply
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", prefix=f"{pod_name}_", delete=False
+        ) as tmp:
+            yaml.dump(manifest, tmp, default_flow_style=False)
+            tmp_path = tmp.name
+
+        try:
+            apply_cmd = self._build_oc_base() + ["apply", "-f", tmp_path]
+            result = subprocess.run(
+                apply_cmd, capture_output=True, text=True, timeout=30
+            )
+            if result.returncode != 0:
+                raise RuntimeError(f"oc apply failed: {result.stderr}")
+            print(f"   Pod {pod_name} created.", flush=True)
+        finally:
+            os.unlink(tmp_path)
+
+        # Wait for pod to be ready
+        print(f"   Waiting for pod {pod_name} to be ready...", flush=True)
+        self._wait_for_ready(pod_name)
+        print(f"   Pod {pod_name} is ready.", flush=True)
+
+        # Start port-forward
+        print(f"   Starting port-forward :{local_port} -> {pod_name}:8000", flush=True)
+        pf_proc = self._start_port_forward(pod_name, local_port)
+        print(f"   Port-forward active (pid={pf_proc.pid}).", flush=True)
+
+        endpoint = f"http://localhost:{local_port}"
+
+        self.active_pods[pod_name] = {
+            "port_forward_proc": pf_proc,
+            "local_port": local_port,
+            "vllm_args": vllm_args,
+            "endpoint": endpoint,
+        }
+
+        return pod_name, endpoint
+
+    def delete_pod(self, pod_name: str) -> None:
+        """Delete an experiment pod and kill its port-forward process.
+
+        Parameters
+        ----------
+        pod_name : str
+            Name of the pod to delete.
+        """
+        info = self.active_pods.pop(pod_name, None)
+
+        # Kill port-forward
+        if info and info.get("port_forward_proc"):
+            proc = info["port_forward_proc"]
+            try:
+                os.kill(proc.pid, signal.SIGTERM)
+                proc.wait(timeout=5)
+            except (OSError, subprocess.TimeoutExpired):
+                try:
+                    os.kill(proc.pid, signal.SIGKILL)
+                except OSError:
+                    pass
+            print(f"   Port-forward for {pod_name} killed.", flush=True)
+
+        # Delete pod
+        delete_cmd = self._build_oc_base() + [
+            "delete",
+            "pod",
+            pod_name,
+            "--grace-period=0",
+            "--force",
+        ]
+        result = subprocess.run(delete_cmd, capture_output=True, text=True, timeout=30)
+        if result.returncode == 0:
+            print(f"   Pod {pod_name} deleted.", flush=True)
+        else:
+            print(
+                f"   Warning: Failed to delete pod {pod_name}: {result.stderr}",
+                flush=True,
+            )
+
+    def cleanup_all(self) -> None:
+        """Delete all active experiment pods. Called at agent exit."""
+        pod_names = list(self.active_pods.keys())
+        if not pod_names:
+            return
+
+        print(
+            f">> PodManager: Cleaning up {len(pod_names)} experiment pod(s)...",
+            flush=True,
+        )
+        for pod_name in pod_names:
+            try:
+                self.delete_pod(pod_name)
+            except Exception as e:
+                print(f"   Warning: cleanup failed for {pod_name}: {e}", flush=True)
+
+    def get_active_pods(self) -> dict[str, dict]:
+        """Return info about active experiment pods."""
+        return dict(self.active_pods)

--- a/auto_tune_vllm/agent/profiler/profiler_config.yaml
+++ b/auto_tune_vllm/agent/profiler/profiler_config.yaml
@@ -1,0 +1,65 @@
+# vLLM Profiler Configuration
+# This file controls torch profiler behavior for instrumented vLLM pods
+
+# Profiling ranges - specify which model execution calls to profile
+# Format: "start-end" or "start1-end1,start2-end2,..." for multiple ranges
+# Examples:
+#   "100-150"           - Profile calls 100 through 150
+#   "50-100,200-300"    - Profile calls 50-100 AND 200-300
+#   "0-50"              - Profile first 50 calls
+profiling_ranges: "100-150"
+
+# Torch profiler activities to record
+# Available: CPU, CUDA
+# Use comma-separated list: "CPU,CUDA"
+activities: "CPU,CUDA"
+
+# Profiler options
+options:
+  # Record tensor shapes in trace
+  record_shapes: true
+
+  # Capture Python stack traces (useful for debugging but adds overhead)
+  with_stack: true
+
+  # Profile memory allocations (adds overhead)
+  profile_memory: false
+
+  # Record function names for better trace readability
+  with_modules: false
+
+# Output configuration
+output:
+  # Export Chrome trace JSON file (can be opened in chrome://tracing)
+  # Set to false to skip trace export (only print table)
+  export_chrome_trace: true
+
+  # Output file path (supports placeholders)
+  # Available placeholders:
+  #   {pid}   - Process ID
+  #   {rank}  - Tensor parallel rank (if available)
+  #   {start} - Start of profiling range
+  #   {end}   - End of profiling range
+  # Note: {start} and {end} are required when using multiple ranges to avoid overwriting files
+  file_pattern: "/tmp/trace_pid{pid}_range{start}-{end}.json"
+
+  # Table output settings
+  table:
+    enabled: true
+    sort_by: "cuda_time_total"  # Options: cuda_time_total, cpu_time_total, cpu_time, cuda_time
+    row_limit: 50
+
+  # Print profiler statistics to logs
+  print_stats: true
+
+# Advanced settings
+advanced:
+  # Module to intercept (change only if using different vLLM version)
+  target_module: "vllm.v1.worker.gpu_worker"
+
+  # Class and method to wrap
+  target_class: "Worker"
+  target_method: "execute_model"
+
+  # Enable debug logging from profiler
+  debug: false

--- a/auto_tune_vllm/agent/profiler/sitecustomize.py
+++ b/auto_tune_vllm/agent/profiler/sitecustomize.py
@@ -1,0 +1,452 @@
+"""
+sitecustomize.py - Auto-loaded PyTorch profiler for vLLM workers
+
+This module is automatically loaded by Python when it starts (via PYTHONPATH).
+It installs an import hook that intercepts vllm.v1.worker.gpu_worker module
+loading and wraps Worker.execute_model with torch.profiler instrumentation.
+
+The profiler records CPU+CUDA activity for configured call ranges, then exports
+Chrome trace JSON files for visualization.
+
+Configuration sources (in priority order):
+1. Environment variables (e.g., VLLM_PROFILER_RANGES="50-100,200-300")
+2. profiler_config.yaml file (if present)
+3. Hardcoded defaults
+"""
+
+import importlib
+import importlib.abc
+import importlib.util
+import os
+import sys
+from typing import List, Optional, Tuple
+
+# ==============================================================================
+# vLLM Configuration
+# ==============================================================================
+
+# Set vLLM RPC timeout (in milliseconds)
+os.environ.setdefault("VLLM_RPC_TIMEOUT", "1800000")
+
+# ==============================================================================
+# Configuration Management
+# ==============================================================================
+
+
+class ProfilerConfig:
+    """Manages profiler configuration from multiple sources."""
+
+    def __init__(self):
+        self.ranges: List[Tuple[int, int]] = []
+        self.activities: List[str] = ["CPU", "CUDA"]
+        self.record_shapes: bool = True
+        self.with_stack: bool = True
+        self.profile_memory: bool = False
+        self.with_modules: bool = False
+        self.export_chrome_trace: bool = True
+        self.output_file_pattern: str = "/tmp/trace_pid{pid}_range{start}-{end}.json"
+        self.table_enabled: bool = True
+        self.table_sort_by: str = "cuda_time_total"
+        self.table_row_limit: int = 50
+        self.print_stats: bool = True
+        self.target_module: str = "vllm.v1.worker.gpu_worker"
+        self.target_class: str = "Worker"
+        self.target_method: str = "execute_model"
+        self.debug: bool = False
+
+        self._load_config()
+
+    def _load_config(self):
+        """Load configuration from environment variables and config file."""
+        # First, try to load from YAML file
+        self._load_from_yaml()
+
+        # Then override with environment variables (highest priority)
+        self._load_from_env()
+
+        # Validate and parse ranges
+        if not self.ranges:
+            # Default range if none specified
+            self.ranges = [(100, 150)]
+
+        if self.debug:
+            print("[profiler-config] Loaded configuration:")
+            print(f"  Ranges: {self.ranges}")
+            print(f"  Activities: {self.activities}")
+            print(f"  Output: {self.output_file_pattern}")
+
+    def _load_from_yaml(self):
+        """Load configuration from profiler_config.yaml if present."""
+        config_path = os.path.join(
+            os.path.dirname(__file__) or "/home/vllm/profiler", "profiler_config.yaml"
+        )
+
+        if not os.path.exists(config_path):
+            return
+
+        try:
+            import yaml
+
+            with open(config_path, "r") as f:
+                config = yaml.safe_load(f)
+
+            if config:
+                # Parse profiling ranges
+                if "profiling_ranges" in config:
+                    self.ranges = self._parse_ranges(config["profiling_ranges"])
+
+                # Activities
+                if "activities" in config:
+                    self.activities = [
+                        a.strip() for a in config["activities"].split(",")
+                    ]
+
+                # Options
+                opts = config.get("options", {})
+                self.record_shapes = opts.get("record_shapes", self.record_shapes)
+                self.with_stack = opts.get("with_stack", self.with_stack)
+                self.profile_memory = opts.get("profile_memory", self.profile_memory)
+                self.with_modules = opts.get("with_modules", self.with_modules)
+
+                # Output configuration
+                output = config.get("output", {})
+                self.export_chrome_trace = output.get(
+                    "export_chrome_trace", self.export_chrome_trace
+                )
+                self.output_file_pattern = output.get(
+                    "file_pattern", self.output_file_pattern
+                )
+                self.print_stats = output.get("print_stats", self.print_stats)
+
+                table = output.get("table", {})
+                self.table_enabled = table.get("enabled", self.table_enabled)
+                self.table_sort_by = table.get("sort_by", self.table_sort_by)
+                self.table_row_limit = table.get("row_limit", self.table_row_limit)
+
+                # Advanced settings
+                adv = config.get("advanced", {})
+                self.target_module = adv.get("target_module", self.target_module)
+                self.target_class = adv.get("target_class", self.target_class)
+                self.target_method = adv.get("target_method", self.target_method)
+                self.debug = adv.get("debug", self.debug)
+
+        except ImportError:
+            # PyYAML not available, skip file-based config
+            pass
+        except Exception as e:
+            print(f"[profiler-config] Warning: Failed to load config file: {e}")
+
+    def _load_from_env(self):
+        """Load configuration from environment variables."""
+        # Profiling ranges
+        if "VLLM_PROFILER_RANGES" in os.environ:
+            self.ranges = self._parse_ranges(os.environ["VLLM_PROFILER_RANGES"])
+
+        # Activities
+        if "VLLM_PROFILER_ACTIVITIES" in os.environ:
+            self.activities = [
+                a.strip() for a in os.environ["VLLM_PROFILER_ACTIVITIES"].split(",")
+            ]
+
+        # Options
+        if "VLLM_PROFILER_RECORD_SHAPES" in os.environ:
+            self.record_shapes = os.environ["VLLM_PROFILER_RECORD_SHAPES"].lower() in (
+                "true",
+                "1",
+                "yes",
+            )
+
+        if "VLLM_PROFILER_WITH_STACK" in os.environ:
+            self.with_stack = os.environ["VLLM_PROFILER_WITH_STACK"].lower() in (
+                "true",
+                "1",
+                "yes",
+            )
+
+        if "VLLM_PROFILER_MEMORY" in os.environ:
+            self.profile_memory = os.environ["VLLM_PROFILER_MEMORY"].lower() in (
+                "true",
+                "1",
+                "yes",
+            )
+
+        # Output file pattern
+        if "VLLM_PROFILER_OUTPUT" in os.environ:
+            self.output_file_pattern = os.environ["VLLM_PROFILER_OUTPUT"]
+
+        # Chrome trace export
+        if "VLLM_PROFILER_EXPORT_TRACE" in os.environ:
+            self.export_chrome_trace = os.environ[
+                "VLLM_PROFILER_EXPORT_TRACE"
+            ].lower() in ("true", "1", "yes")
+
+        # Debug mode
+        if "VLLM_PROFILER_DEBUG" in os.environ:
+            self.debug = os.environ["VLLM_PROFILER_DEBUG"].lower() in (
+                "true",
+                "1",
+                "yes",
+            )
+
+    def _parse_ranges(self, ranges_str: str) -> List[Tuple[int, int]]:
+        """
+        Parse profiling ranges from string format.
+
+        Examples:
+            "100-150" -> [(100, 150)]
+            "50-100,200-300" -> [(50, 100), (200, 300)]
+            "0-50,100-150,300-350" -> [(0, 50), (100, 150), (300, 350)]
+        """
+        ranges = []
+        for range_str in ranges_str.split(","):
+            range_str = range_str.strip()
+            if "-" in range_str:
+                try:
+                    start, end = range_str.split("-")
+                    ranges.append((int(start), int(end)))
+                except ValueError as e:
+                    print(
+                        f"[profiler-config] Warning: Invalid range '{range_str}': {e}"
+                    )
+        return ranges
+
+    def get_output_filename(
+        self,
+        pid: Optional[int] = None,
+        rank: Optional[int] = None,
+        range_start: Optional[int] = None,
+        range_end: Optional[int] = None,
+    ) -> str:
+        """Generate output filename with substitutions."""
+        filename = self.output_file_pattern
+        filename = filename.replace("{pid}", str(pid or os.getpid()))
+        if rank is not None:
+            filename = filename.replace("{rank}", str(rank))
+        if range_start is not None:
+            filename = filename.replace("{start}", str(range_start))
+        if range_end is not None:
+            filename = filename.replace("{end}", str(range_end))
+        return filename
+
+
+# Global configuration instance
+_config = ProfilerConfig()
+
+
+# ==============================================================================
+# Import Hook
+# ==============================================================================
+
+
+class PostImportLoader(importlib.abc.Loader):
+    def __init__(self, loader):
+        self.loader = loader
+
+    def create_module(self, spec):
+        if hasattr(self.loader, "create_module"):
+            return self.loader.create_module(spec)
+        return None
+
+    def exec_module(self, module):
+        self.loader.exec_module(module)
+        if _config.debug:
+            print(f"[profiler] {module.__name__} loaded")
+        safe_wrap_function(module)
+        if _config.debug:
+            print(f"[profiler] {module.__name__} wrapped")
+
+
+class PostImportFinder(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        if fullname != _config.target_module:
+            return None
+
+        # Prevent recursive lookup
+        sys.meta_path.remove(self)
+        try:
+            spec = importlib.util.find_spec(fullname)
+        finally:
+            sys.meta_path.insert(0, self)
+
+        if spec and spec.loader:
+            spec.loader = PostImportLoader(spec.loader)
+            return spec
+        return None
+
+
+# Install the import hook
+sys.meta_path.insert(0, PostImportFinder())
+
+
+# ==============================================================================
+# Profiler Wrapper
+# ==============================================================================
+
+
+def wrap_func_with_profiler(original_func):
+    """
+    Wraps a function with PyTorch profiler that activates for configured ranges.
+
+    Supports multiple profiling windows, e.g., calls 50-100 and 200-300.
+    """
+    import functools
+
+    from torch.profiler import ProfilerActivity, profile
+
+    # Parse activities
+    activities = []
+    for activity in _config.activities:
+        if activity.upper() == "CPU":
+            activities.append(ProfilerActivity.CPU)
+        elif activity.upper() == "CUDA":
+            activities.append(ProfilerActivity.CUDA)
+
+    # Create profiler instance
+    prof = profile(
+        activities=activities,
+        record_shapes=_config.record_shapes,
+        with_stack=_config.with_stack,
+        profile_memory=_config.profile_memory,
+        with_modules=_config.with_modules,
+    )
+
+    # Track call count and current profiling range index
+    count = 0
+    current_range_idx = 0
+    profiling_active = False
+
+    @functools.wraps(original_func)
+    def wrapped_func(*args, **kwargs):
+        nonlocal count, current_range_idx, profiling_active, prof
+
+        count += 1
+
+        # Check if we should start profiling
+        if not profiling_active and current_range_idx < len(_config.ranges):
+            start, end = _config.ranges[current_range_idx]
+            if count == start:
+                print(
+                    f"[profiler] Starting profiler for range {start}-{end} (call #{count})"
+                )
+                prof.start()
+                profiling_active = True
+
+        # Check if we should stop profiling
+        if profiling_active:
+            start, end = _config.ranges[current_range_idx]
+            if count == end:
+                print(
+                    f"[profiler] Stopping profiler for range {start}-{end} (call #{count})"
+                )
+                prof.stop()
+                profiling_active = False
+
+                # Print and export results
+                if _config.print_stats:
+                    print("===== begin profiler output")
+                    if _config.table_enabled:
+                        print(
+                            prof.key_averages().table(
+                                sort_by=_config.table_sort_by,
+                                row_limit=_config.table_row_limit,
+                            )
+                        )
+                    print("===== end profiler output")
+
+                # Optionally export Chrome trace file
+                if _config.export_chrome_trace:
+                    output_file = _config.get_output_filename(
+                        range_start=start, range_end=end
+                    )
+                    prof.export_chrome_trace(output_file)
+                    print(f"[profiler] Exported trace to: {output_file}")
+                else:
+                    print(
+                        "[profiler] Chrome trace export disabled (export_chrome_trace=false)"
+                    )
+
+                # Move to next range
+                current_range_idx += 1
+
+                # Create new profiler for next range if exists
+                if current_range_idx < len(_config.ranges):
+                    prof = profile(
+                        activities=activities,
+                        record_shapes=_config.record_shapes,
+                        with_stack=_config.with_stack,
+                        profile_memory=_config.profile_memory,
+                        with_modules=_config.with_modules,
+                    )
+
+        # Call original function
+        result = original_func(*args, **kwargs)
+        return result
+
+    return wrapped_func
+
+
+# ==============================================================================
+# Helper Functions
+# ==============================================================================
+
+
+def safe_wrap_function(module=None):
+    """Safely wrap the target function with error handling."""
+    try:
+        mod = module or sys.modules.get(_config.target_module)
+        if mod is None:
+            return
+        wrap_function(mod)
+    except Exception as e:
+        print(f"[profiler] Error wrapping function: {e}")
+        if _config.debug:
+            import traceback
+
+            traceback.print_exc()
+
+
+def wrap_function(mod):
+    """Wrap the target method with profiler."""
+    target_class = getattr(mod, _config.target_class, None)
+    if target_class is None:
+        print(
+            f"[profiler] Warning: Class '{_config.target_class}' not found in {mod.__name__}"
+        )
+        return
+
+    original_method = getattr(target_class, _config.target_method, None)
+    if original_method is None:
+        print(
+            f"[profiler] Warning: Method '{_config.target_method}' not found in {_config.target_class}"
+        )
+        return
+
+    if _config.debug:
+        print(f"[profiler] Wrapping {_config.target_class}.{_config.target_method}")
+
+    setattr(
+        target_class, _config.target_method, wrap_func_with_profiler(original_method)
+    )
+
+
+def unwrap_function():
+    """Remove profiler wrapping (for debugging)."""
+    import vllm.v1.worker.gpu_worker
+
+    vllm.v1.worker.gpu_worker.Worker.execute_model = (
+        vllm.v1.worker.gpu_worker.Worker.execute_model.__wrapped__
+    )
+
+
+# ==============================================================================
+# Startup
+# ==============================================================================
+
+print(
+    f"[profiler] vLLM profiler installed - will profile ranges: {_config.ranges}",
+    file=sys.stderr,
+)
+print(
+    f"[profiler] Target: {_config.target_module}.{_config.target_class}.{_config.target_method}",
+    file=sys.stderr,
+)

--- a/auto_tune_vllm/agent/reporter.py
+++ b/auto_tune_vllm/agent/reporter.py
@@ -1,0 +1,399 @@
+"""
+Markdown & JSON Report Generation for vLLM Performance Tuning
+
+Generates the final performance tuning report with before/after comparisons,
+kernel analysis, cost efficiency, and token usage.
+
+SOURCE: ai-perf-hackathon/agent/reporter.py (adapted for vLLM metrics)
+"""
+
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+@dataclass
+class BenchmarkSnapshot:
+    """Benchmark results for a single profile at a single concurrency."""
+
+    profile: str
+    concurrency: int
+    throughput_tok_per_sec: float = 0.0
+    ttft_p50: float = 0.0
+    ttft_p95: float = 0.0
+    ttft_p99: float = 0.0
+    itl_p50: float = 0.0
+    itl_p95: float = 0.0
+    itl_p99: float = 0.0
+    tpot_p50: float = 0.0
+    tpot_p95: float = 0.0
+    tpot_p99: float = 0.0
+    request_success_rate: float = 100.0
+
+    def to_dict(self) -> dict:
+        return {
+            "profile": self.profile,
+            "concurrency": self.concurrency,
+            "throughput_tok_per_sec": self.throughput_tok_per_sec,
+            "ttft_p50": self.ttft_p50,
+            "ttft_p95": self.ttft_p95,
+            "ttft_p99": self.ttft_p99,
+            "itl_p50": self.itl_p50,
+            "itl_p95": self.itl_p95,
+            "itl_p99": self.itl_p99,
+            "tpot_p50": self.tpot_p50,
+            "tpot_p95": self.tpot_p95,
+            "tpot_p99": self.tpot_p99,
+            "request_success_rate": self.request_success_rate,
+        }
+
+
+@dataclass
+class TuningReport:
+    """Complete vLLM performance tuning report."""
+
+    timestamp: str = ""
+    model_name: str = ""
+    vllm_endpoint: str = ""
+    gpu_info: str = ""
+    vllm_config: dict = field(default_factory=dict)
+    baseline_results: list = field(default_factory=list)
+    final_results: list = field(default_factory=list)
+    kernel_analysis: dict = field(default_factory=dict)
+    actions_taken: list = field(default_factory=list)
+    bottlenecks: list = field(default_factory=list)
+    agent_summary: str = ""
+    token_usage: list = field(default_factory=list)
+    decision_log: list = field(default_factory=list)
+
+
+class Reporter:
+    """Generates vLLM performance tuning reports."""
+
+    def __init__(self, output_dir: str = "reports"):
+        self.output_dir = output_dir
+
+    def generate(self, report: TuningReport) -> tuple:
+        """Generate both markdown and JSON reports. Returns (md_path, json_path)."""
+        os.makedirs(self.output_dir, exist_ok=True)
+        ts = report.timestamp or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        md_path = os.path.join(self.output_dir, f"report_{ts}.md")
+        json_path = os.path.join(self.output_dir, f"report_{ts}.json")
+
+        md_content = self._generate_markdown(report)
+        json_content = self._generate_json(report)
+
+        with open(md_path, "w") as f:
+            f.write(md_content)
+        with open(json_path, "w") as f:
+            f.write(json_content)
+
+        return md_path, json_path
+
+    def _generate_markdown(self, report: TuningReport) -> str:
+        """Generate a markdown report."""
+        sections = [
+            self._header_section(report),
+            self._executive_summary_section(report),
+            self._performance_results_section(report),
+            self._bottlenecks_section(report),
+            self._kernel_analysis_section(report),
+            self._tuning_applied_section(report),
+            self._cost_analysis_section(report),
+            self._token_usage_section(report),
+            self._system_config_section(report),
+            self._footer_section(),
+        ]
+        return "\n".join(sections)
+
+    def _header_section(self, report: TuningReport) -> str:
+        return "\n".join(
+            [
+                "# vLLM Performance Tuning Report",
+                "",
+                f"**Generated**: {report.timestamp}",
+                f"**Model**: {report.model_name}",
+                f"**Endpoint**: {report.vllm_endpoint}",
+                f"**GPU**: {report.gpu_info}",
+                "",
+                "---",
+                "",
+            ]
+        )
+
+    def _executive_summary_section(self, report: TuningReport) -> str:
+        return "\n".join(
+            [
+                "## Executive Summary",
+                "",
+                report.agent_summary or "*No summary provided by agent.*",
+                "",
+                "---",
+                "",
+            ]
+        )
+
+    def _performance_results_section(self, report: TuningReport) -> str:
+        lines = [
+            "## Performance Results",
+            "",
+            "### Before vs After Comparison",
+            "",
+            "| Profile | Metric | Before | After | Change |",
+            "|---------|--------|--------|-------|--------|",
+        ]
+
+        # Group by profile
+        baseline_map = {}
+        for r in report.baseline_results:
+            key = r.get("profile", "") if isinstance(r, dict) else r.profile
+            baseline_map[key] = r
+
+        final_map = {}
+        for r in report.final_results:
+            key = r.get("profile", "") if isinstance(r, dict) else r.profile
+            final_map[key] = r
+
+        for profile in ["balanced", "decode_heavy", "prefill_heavy", "long_context"]:
+            base = baseline_map.get(profile)
+            final = final_map.get(profile)
+            if not base and not final:
+                continue
+
+            def _val(obj, key):
+                if obj is None:
+                    return 0.0
+                if isinstance(obj, dict):
+                    return obj.get(key, 0.0)
+                return getattr(obj, key, 0.0)
+
+            metrics = [
+                ("Throughput (tok/s)", "throughput_tok_per_sec", True),
+                ("TTFT P50 (ms)", "ttft_p50", False),
+                ("TTFT P99 (ms)", "ttft_p99", False),
+                ("ITL P50 (ms)", "itl_p50", False),
+                ("ITL P99 (ms)", "itl_p99", False),
+            ]
+
+            for metric_name, key, higher_is_better in metrics:
+                before = _val(base, key)
+                after = _val(final, key)
+                if before > 0:
+                    pct = ((after - before) / before) * 100
+                    sign = "+" if pct >= 0 else ""
+                    # For latency metrics, negative change is good
+                    if not higher_is_better:
+                        good = pct <= 0
+                    else:
+                        good = pct >= 0
+                    indicator = "**" if good else ""
+                    change = f"{indicator}{sign}{pct:.1f}%{indicator}"
+                else:
+                    change = "N/A"
+                lines.append(
+                    f"| {profile} | {metric_name} | {before:.1f} | {after:.1f} | {change} |"
+                )
+
+        lines.extend(["", "---", ""])
+        return "\n".join(lines)
+
+    def _bottlenecks_section(self, report: TuningReport) -> str:
+        lines = ["## Bottlenecks Identified", ""]
+        if report.bottlenecks:
+            for i, b in enumerate(report.bottlenecks, 1):
+                lines.append(f"{i}. {b}")
+        else:
+            lines.append("*No specific bottlenecks identified.*")
+        lines.extend(["", "---", ""])
+        return "\n".join(lines)
+
+    def _kernel_analysis_section(self, report: TuningReport) -> str:
+        lines = ["## Kernel Analysis (PyTorch Profiler)", ""]
+        ka = report.kernel_analysis
+        if not ka:
+            lines.append("*Profiling was not performed in this run.*")
+            lines.extend(["", "---", ""])
+            return "\n".join(lines)
+
+        # Top kernels
+        top_kernels = ka.get("top_kernels", [])
+        if top_kernels:
+            lines.extend(
+                [
+                    "### Top CUDA Kernels by Time",
+                    "",
+                    "| Rank | Kernel | Category | GPU Time (ms) | % Total |",
+                    "|------|--------|----------|---------------|---------|",
+                ]
+            )
+            for i, k in enumerate(top_kernels[:15], 1):
+                name = k.get("name", "unknown")[:50]
+                cat = k.get("category", "")
+                time_ms = k.get("gpu_time_ms", 0)
+                pct = k.get("pct_total", 0)
+                lines.append(f"| {i} | `{name}` | {cat} | {time_ms:.2f} | {pct:.1f}% |")
+            lines.append("")
+
+        # Category breakdown
+        categories = ka.get("category_breakdown", {})
+        if categories:
+            lines.extend(
+                [
+                    "### GPU Time by Category",
+                    "",
+                    "| Category | GPU Time (ms) | % Total |",
+                    "|----------|---------------|---------|",
+                ]
+            )
+            for cat, data in categories.items():
+                time_ms = data.get("gpu_time_ms", 0)
+                pct = data.get("pct_total", 0)
+                lines.append(f"| {cat} | {time_ms:.2f} | {pct:.1f}% |")
+            lines.append("")
+
+        lines.extend(["---", ""])
+        return "\n".join(lines)
+
+    def _tuning_applied_section(self, report: TuningReport) -> str:
+        lines = ["## Tuning Applied", ""]
+        if report.actions_taken:
+            lines.extend(
+                [
+                    "| # | Action | Details | Timestamp |",
+                    "|---|--------|---------|-----------|",
+                ]
+            )
+            for i, action in enumerate(report.actions_taken, 1):
+                atype = action.get("type", "unknown")
+                path = action.get("path", action.get("command", ""))[:50]
+                ts = action.get("timestamp", "")
+                lines.append(f"| {i} | {atype} | `{path}` | {ts} |")
+        else:
+            lines.append("*No tuning actions were applied.*")
+        lines.extend(["", "---", ""])
+        return "\n".join(lines)
+
+    def _cost_analysis_section(self, report: TuningReport) -> str:
+        lines = ["## Cost Analysis", ""]
+
+        # Calculate CPMT if we have throughput data
+        final_map = {}
+        for r in report.final_results:
+            key = r.get("profile", "") if isinstance(r, dict) else r.profile
+            final_map[key] = r
+
+        if final_map:
+            lines.extend(
+                [
+                    "### Cost Per Million Tokens (CPMT)",
+                    "",
+                    "| Profile | Throughput (tok/s) | CPMT ($/M tokens) |",
+                    "|---------|--------------------|--------------------|",
+                ]
+            )
+            # H100 pricing ~$2.50/hr (approximate cloud pricing)
+            hourly_cost = 2.50
+            for profile, result in final_map.items():
+                if isinstance(result, dict):
+                    throughput = result.get("throughput_tok_per_sec", 0)
+                else:
+                    throughput = getattr(result, "throughput_tok_per_sec", 0)
+                if throughput > 0:
+                    tokens_per_hour = throughput * 3600
+                    cpmt = (hourly_cost / tokens_per_hour) * 1_000_000
+                    lines.append(f"| {profile} | {throughput:.0f} | ${cpmt:.4f} |")
+        else:
+            lines.append("*No cost data available.*")
+
+        lines.extend(["", "---", ""])
+        return "\n".join(lines)
+
+    def _token_usage_section(self, report: TuningReport) -> str:
+        lines = [
+            "## Claude API Token Usage",
+            "",
+            "| Model | Input Tokens | Output Tokens | Total | API Calls | Est. Cost |",
+            "|-------|--------------|---------------|-------|-----------|-----------|",
+        ]
+
+        total_input = 0
+        total_output = 0
+        total_calls = 0
+        total_cost = 0
+
+        for usage in report.token_usage:
+            inp = usage.get("input_tokens", 0)
+            out = usage.get("output_tokens", 0)
+            total = inp + out
+            calls = usage.get("api_calls", 0)
+            cost = usage.get("cost_usd", 0)
+            model = usage.get("model", "unknown")
+            lines.append(
+                f"| {model} | {inp:,} | {out:,} | {total:,} | {calls} | ${cost:.4f} |"
+            )
+            total_input += inp
+            total_output += out
+            total_calls += calls
+            total_cost += cost
+
+        lines.append(
+            f"| **Total** | **{total_input:,}** | **{total_output:,}** | "
+            f"**{total_input + total_output:,}** | **{total_calls}** | **${total_cost:.4f}** |"
+        )
+
+        lines.extend(["", "---", ""])
+        return "\n".join(lines)
+
+    def _system_config_section(self, report: TuningReport) -> str:
+        lines = [
+            "## System Configuration",
+            "",
+            f"- **Model**: {report.model_name}",
+            f"- **GPU**: {report.gpu_info}",
+            f"- **Endpoint**: {report.vllm_endpoint}",
+            "",
+        ]
+
+        if report.vllm_config:
+            lines.append("### vLLM Parameters")
+            lines.append("")
+            for key, value in report.vllm_config.items():
+                lines.append(f"- `{key}`: {value}")
+            lines.append("")
+
+        lines.extend(["---", ""])
+        return "\n".join(lines)
+
+    def _footer_section(self) -> str:
+        return "\n".join(
+            [
+                "",
+                "*Report generated by auto-tune-vllm agentic tuner*",
+            ]
+        )
+
+    def _generate_json(self, report: TuningReport) -> str:
+        """Generate a JSON report."""
+        data = {
+            "timestamp": report.timestamp,
+            "model_name": report.model_name,
+            "vllm_endpoint": report.vllm_endpoint,
+            "gpu_info": report.gpu_info,
+            "vllm_config": report.vllm_config,
+            "agent_summary": report.agent_summary,
+            "bottlenecks": report.bottlenecks,
+            "baseline_results": [
+                r.to_dict() if hasattr(r, "to_dict") else r
+                for r in report.baseline_results
+            ],
+            "final_results": [
+                r.to_dict() if hasattr(r, "to_dict") else r
+                for r in report.final_results
+            ],
+            "kernel_analysis": report.kernel_analysis,
+            "actions_taken": report.actions_taken,
+            "token_usage": report.token_usage,
+            "decision_log": report.decision_log,
+        }
+        return json.dumps(data, indent=2)

--- a/auto_tune_vllm/agent/settings.yaml
+++ b/auto_tune_vllm/agent/settings.yaml
@@ -1,0 +1,91 @@
+# Default settings for the agentic vLLM tuner.
+#
+# These conservative ISL/OSL values match the hackathon demo (opt-125m on H100).
+# Increase prompt/output tokens for production-scale models.
+
+profiles:
+  balanced:
+    input_sequence_length: 128
+    output_sequence_length: 128
+    samples: 100
+    description: "Balanced workload (ISL=128, OSL=128)"
+  decode_heavy:
+    input_sequence_length: 128
+    output_sequence_length: 512
+    samples: 100
+    description: "Decode-heavy workload (ISL=128, OSL=512)"
+  prefill_heavy:
+    input_sequence_length: 512
+    output_sequence_length: 64
+    samples: 100
+    description: "Prefill-heavy workload (ISL=512, OSL=64)"
+  long_context:
+    input_sequence_length: 1024
+    output_sequence_length: 128
+    samples: 100
+    description: "Long-context workload (ISL=1024, OSL=128)"
+
+# Default sweep used by run_benchmark. Override per-call with the concurrency arg.
+default_concurrency_levels: [1, 50]
+
+# Full sweep kept for reference if you want a wider load test.
+concurrency_levels: [1, 50, 100, 200, 300, 500, 650]
+
+tunable_params:
+  max_num_seqs:
+    default: 256
+    range: [1, 1024]
+    description: "Maximum number of sequences per iteration"
+  max_num_batched_tokens:
+    default: null
+    range: [256, 32768]
+    description: "Maximum number of batched tokens per iteration"
+  gpu_memory_utilization:
+    default: 0.90
+    range: [0.80, 0.95]
+    description: "Fraction of GPU memory for KV cache"
+  enable_chunked_prefill:
+    default: false
+    description: "Enable chunked prefill for long sequences"
+  enable_prefix_caching:
+    default: false
+    description: "Enable automatic prefix caching"
+  max_model_len:
+    default: null
+    description: "Maximum model context length"
+  enforce_eager:
+    default: false
+    description: "Disable CUDA graphs, use eager mode"
+  tensor_parallel_size:
+    default: 1
+    range: [1, 8]
+    description: "Number of GPUs for tensor parallelism"
+  quantization:
+    default: null
+    options: [null, "fp8", "awq", "gptq"]
+    description: "Quantization method"
+  scheduling_policy:
+    default: "fcfs"
+    options: ["fcfs", "priority"]
+    description: "Request scheduling policy"
+  kv_cache_dtype:
+    default: "auto"
+    options: ["auto", "fp8"]
+    description: "KV cache data type"
+  cuda_graph_max_capture_size:
+    default: 2048
+    description: "Max batch size for CUDA graph capture"
+
+metrics:
+  - throughput_tok_per_sec
+  - ttft_p50
+  - ttft_p95
+  - ttft_p99
+  - itl_p50
+  - itl_p95
+  - itl_p99
+  - tpot_p50
+  - tpot_p95
+  - tpot_p99
+
+regression_threshold: 0.02

--- a/auto_tune_vllm/agent/ssh_client.py
+++ b/auto_tune_vllm/agent/ssh_client.py
@@ -1,0 +1,83 @@
+"""
+SSH client for remote command execution.
+"""
+
+import subprocess
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class SSHResult:
+    """Result of SSH command execution."""
+
+    stdout: str
+    stderr: str
+    returncode: int
+    success: bool
+
+    @property
+    def output(self) -> str:
+        return self.stdout if self.success else self.stderr
+
+
+class SSHClient:
+    """Simple SSH client using subprocess."""
+
+    def __init__(self, host: str, user: str = "root", timeout: int = 30):
+        self.host = host
+        self.user = user
+        self.timeout = timeout
+
+    def run(self, command: str, timeout: Optional[int] = None) -> SSHResult:
+        """Execute command on remote host via SSH."""
+        timeout = timeout or self.timeout
+        ssh_cmd = [
+            "ssh",
+            "-T",  # Disable pseudo-terminal allocation (prevents TTY escape codes)
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            f"ConnectTimeout={timeout}",
+            f"{self.user}@{self.host}",
+            command,
+        ]
+
+        try:
+            result = subprocess.run(
+                ssh_cmd, capture_output=True, text=True, timeout=timeout + 10
+            )
+            # Clean carriage returns that mess up terminal output
+            stdout = result.stdout.replace("\r\n", "\n").replace("\r", "\n")
+            stderr = result.stderr.replace("\r\n", "\n").replace("\r", "\n")
+            return SSHResult(
+                stdout=stdout,
+                stderr=stderr,
+                returncode=result.returncode,
+                success=result.returncode == 0,
+            )
+        except subprocess.TimeoutExpired:
+            return SSHResult(
+                stdout="",
+                stderr=f"Command timed out after {timeout}s",
+                returncode=-1,
+                success=False,
+            )
+        except Exception as e:
+            return SSHResult(stdout="", stderr=str(e), returncode=-1, success=False)
+
+    def write_file(self, path: str, content: str) -> SSHResult:
+        """Write content to a file on remote host."""
+        command = f"cat > {path} << 'EOFAGENT'\n{content}\nEOFAGENT"
+        return self.run(command)
+
+    def read_file(self, path: str) -> SSHResult:
+        """Read file content from remote host."""
+        return self.run(f"cat {path}")
+
+    def test_connection(self) -> bool:
+        """Test SSH connectivity."""
+        result = self.run("echo ok", timeout=10)
+        return result.success and "ok" in result.stdout

--- a/auto_tune_vllm/agent/tools.py
+++ b/auto_tune_vllm/agent/tools.py
@@ -1,0 +1,2047 @@
+"""
+Tool Definitions & Dispatch
+
+Defines all tools available to the Claude agent and their handler functions.
+
+SOURCE: ai-perf-hackathon/agent/tools.py (core tools reused, new tools added)
+
+Core Tools (from ai-perf-hackathon, adapted for RemoteExecutor):
+    - run_command(command, timeout)    -- Execute shell command on vLLM host/pod
+    - read_file(path)                 -- Read file contents from vLLM host/pod
+    - write_file(path, content)       -- Write file to vLLM host/pod
+    - done(summary, success)          -- Signal agent completion
+
+New Benchmark Tool:
+    - run_benchmark(profile, concurrency, endpoint, model)
+        Wraps GuideLLM to run benchmarks against vLLM endpoint.
+        Profiles: Balanced (ISL=128,OSL=128), Decode-Heavy (ISL=128,OSL=512),
+                  Prefill-Heavy (ISL=512,OSL=64), Long-Context (ISL=1024,OSL=128)
+        Default concurrency sweep: 1, 50
+        Output: throughput (tok/sec), TTFT, ITL, TPOT at P50/P95/P99
+
+New Analysis Tools:
+    - analyze_trace(trace_json_path)
+        Calls analysis/trace_analyzer.py to extract kernel stats, category breakdown.
+    - map_kernel(kernel_name)
+        Calls analysis/kernel_mapper.py to identify vLLM source for hot kernels.
+
+Architecture:
+    RemoteExecutor abstracts over SSH and OpenShift (`oc exec`) execution modes.
+    - OcExecutor(namespace, pod_name, kubeconfig) -- runs `oc exec` via subprocess
+    - SSHExecutor(ssh_client) -- wraps the existing SSHClient
+
+Tool Definition Format:
+    Each tool is a dict with: name, description, input_schema (JSON Schema)
+    Compatible with Claude's tool_use API format.
+
+Dispatch:
+    dispatch_tool(name, args, executor) -> ToolResult
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from .pod_manager import PodManager
+from .ssh_client import SSHClient
+
+# ---------------------------------------------------------------------------
+# ToolResult
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ToolResult:
+    """Result from a tool execution."""
+
+    tool: str
+    success: bool
+    output: str
+    error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        d = {"tool": self.tool, "success": self.success, "output": self.output}
+        if self.error:
+            d["error"] = self.error
+        return d
+
+
+# ---------------------------------------------------------------------------
+# RemoteExecutor abstraction
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CommandResult:
+    """Unified result from a remote command execution."""
+
+    stdout: str
+    stderr: str
+    returncode: int
+    success: bool
+
+    @property
+    def output(self) -> str:
+        return self.stdout if self.success else self.stderr
+
+
+class RemoteExecutor(ABC):
+    """Abstract base for executing commands on a remote vLLM host/pod."""
+
+    @abstractmethod
+    def run(self, command: str, timeout: int = 60) -> CommandResult:
+        """Execute a command on the remote target."""
+        ...
+
+    @abstractmethod
+    def read_file(self, path: str) -> CommandResult:
+        """Read a file from the remote target."""
+        ...
+
+    @abstractmethod
+    def write_file(self, path: str, content: str) -> CommandResult:
+        """Write content to a file on the remote target."""
+        ...
+
+    @abstractmethod
+    def test_connection(self) -> bool:
+        """Test connectivity to the remote target."""
+        ...
+
+
+class SSHExecutor(RemoteExecutor):
+    """Execute commands on the vLLM host via SSH.
+
+    Wraps the existing SSHClient for backward compatibility with the
+    ai-perf-hackathon SSH-based workflow.
+    """
+
+    def __init__(self, ssh_client: SSHClient):
+        self._client = ssh_client
+
+    def run(self, command: str, timeout: int = 60) -> CommandResult:
+        result = self._client.run(command, timeout=timeout)
+        return CommandResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            returncode=result.returncode,
+            success=result.success,
+        )
+
+    def read_file(self, path: str) -> CommandResult:
+        result = self._client.read_file(path)
+        return CommandResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            returncode=result.returncode,
+            success=result.success,
+        )
+
+    def write_file(self, path: str, content: str) -> CommandResult:
+        result = self._client.write_file(path, content)
+        return CommandResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            returncode=result.returncode,
+            success=result.success,
+        )
+
+    def test_connection(self) -> bool:
+        return self._client.test_connection()
+
+
+class OcExecutor(RemoteExecutor):
+    """Execute commands on a vLLM pod via ``oc exec`` (OpenShift).
+
+    Parameters
+    ----------
+    namespace : str
+        Kubernetes namespace where the vLLM pod runs.
+    pod_name : str
+        Name (or label selector) of the vLLM pod.
+    kubeconfig : str or None
+        Path to a kubeconfig file. If *None*, the default kubeconfig
+        (``~/.kube/config`` or ``$KUBECONFIG``) is used.
+    container : str or None
+        Container name inside the pod. If *None*, the default container
+        is used (Kubernetes picks the first one).
+    """
+
+    def __init__(
+        self,
+        namespace: str,
+        pod_name: str,
+        kubeconfig: Optional[str] = None,
+        container: Optional[str] = None,
+    ):
+        self.namespace = namespace
+        self.pod_name = pod_name
+        self.kubeconfig = kubeconfig
+        self.container = container
+
+    def _build_oc_cmd(self, command: str) -> list[str]:
+        """Build the full ``oc exec`` command list."""
+        cmd = ["oc"]
+        if self.kubeconfig:
+            cmd += ["--kubeconfig", self.kubeconfig]
+        cmd += ["exec", "-n", self.namespace]
+        if self.container:
+            cmd += ["-c", self.container]
+        cmd += [self.pod_name, "--"]
+        # Use /bin/sh -c to support shell features (pipes, redirects, etc.)
+        cmd += ["/bin/sh", "-c", command]
+        return cmd
+
+    def run(self, command: str, timeout: int = 60) -> CommandResult:
+        oc_cmd = self._build_oc_cmd(command)
+        try:
+            result = subprocess.run(
+                oc_cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout + 10,
+            )
+            stdout = result.stdout.replace("\r\n", "\n").replace("\r", "\n")
+            stderr = result.stderr.replace("\r\n", "\n").replace("\r", "\n")
+            return CommandResult(
+                stdout=stdout,
+                stderr=stderr,
+                returncode=result.returncode,
+                success=result.returncode == 0,
+            )
+        except subprocess.TimeoutExpired:
+            return CommandResult(
+                stdout="",
+                stderr=f"oc exec timed out after {timeout}s",
+                returncode=-1,
+                success=False,
+            )
+        except Exception as e:
+            return CommandResult(
+                stdout="",
+                stderr=str(e),
+                returncode=-1,
+                success=False,
+            )
+
+    def read_file(self, path: str) -> CommandResult:
+        return self.run(f"cat {shlex.quote(path)}")
+
+    def write_file(self, path: str, content: str) -> CommandResult:
+        return self.run(f"cat > {shlex.quote(path)} << 'EOFAGENT'\n{content}\nEOFAGENT")
+
+    def test_connection(self) -> bool:
+        result = self.run("echo ok", timeout=15)
+        return result.success and "ok" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Benchmark profiles (loaded from settings.yaml)
+# ---------------------------------------------------------------------------
+
+
+def _load_settings() -> dict:
+    settings_path = Path(__file__).with_name("settings.yaml")
+    with open(settings_path, encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def _build_benchmark_profiles(settings: dict) -> dict:
+    profiles = {}
+    for name, profile in (settings.get("profiles") or {}).items():
+        isl = int(profile["input_sequence_length"])
+        osl = int(profile["output_sequence_length"])
+        samples = int(profile.get("samples", 100))
+        profiles[name] = {
+            "isl": isl,
+            "osl": osl,
+            "description": profile.get("description", name),
+            "data_flag": json.dumps(
+                {"prompt_tokens": isl, "output_tokens": osl, "samples": samples}
+            ),
+        }
+    return profiles
+
+
+_SETTINGS = _load_settings()
+BENCHMARK_PROFILES = _build_benchmark_profiles(_SETTINGS)
+DEFAULT_CONCURRENCY_LEVELS = list(
+    _SETTINGS.get("default_concurrency_levels") or [1, 50]
+)
+PROFILE_CHOICES = list(BENCHMARK_PROFILES.keys()) or [
+    "balanced",
+    "decode_heavy",
+    "prefill_heavy",
+    "long_context",
+]
+
+
+# ---------------------------------------------------------------------------
+# Tool Definitions (for Claude's tool_use API)
+# ---------------------------------------------------------------------------
+
+TOOL_DEFINITIONS: list[dict] = [
+    {
+        "name": "run_command",
+        "description": (
+            "Run a shell command on the vLLM host/pod for diagnostics. "
+            "Use this to check GPU status, inspect vLLM configs, and read process state. "
+            "The command runs on the remote target (SSH host or OpenShift pod). "
+            "Never kill or restart the baseline pod. "
+            "Optionally specify pod_name to run on an experiment pod instead of the baseline."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "The shell command to execute on the vLLM host/pod",
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": (
+                        "Command timeout in seconds. Default is 60. "
+                        "Increase for long-running operations (e.g. model reload)."
+                    ),
+                    "default": 60,
+                },
+                "pod_name": {
+                    "type": "string",
+                    "description": (
+                        "Optional: name of an experiment pod to run the command on "
+                        "(created by create_vllm_pod). If omitted, runs on the baseline pod."
+                    ),
+                },
+            },
+            "required": ["command"],
+        },
+    },
+    {
+        "name": "read_file",
+        "description": (
+            "Read the contents of a file on the vLLM host/pod. "
+            "Use this to inspect configuration files, logs, profiler output, etc."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to the file on the vLLM host/pod",
+                },
+            },
+            "required": ["path"],
+        },
+    },
+    {
+        "name": "write_file",
+        "description": (
+            "Write content to a file on the vLLM host/pod. "
+            "Use this to modify vLLM configuration, create scripts, "
+            "or write profiler setup files."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to the file on the vLLM host/pod",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Content to write to the file",
+                },
+            },
+            "required": ["path", "content"],
+        },
+    },
+    {
+        "name": "run_benchmark",
+        "description": (
+            "Run a GuideLLM benchmark against the vLLM endpoint from the LOCAL machine. "
+            "This measures throughput (tokens/sec), TTFT, ITL, and TPOT at P50/P95/P99. "
+            "Choose a profile to set ISL/OSL and concurrency for the load pattern. "
+            "Default profiles: balanced (ISL=128,OSL=128), decode_heavy (ISL=128,OSL=512), "
+            "prefill_heavy (ISL=512,OSL=64), long_context (ISL=1024,OSL=128). "
+            "The benchmark takes 2-10 minutes depending on max-seconds. "
+            "Results are saved as JSON and a summary is returned."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "profile": {
+                    "type": "string",
+                    "enum": PROFILE_CHOICES,
+                    "description": (
+                        "Benchmark workload profile. Controls ISL/OSL ratios. "
+                        "balanced: equal read/write, decode_heavy: long generation, "
+                        "prefill_heavy: long context input, long_context: very large input."
+                    ),
+                },
+                "concurrency": {
+                    "type": "string",
+                    "description": (
+                        "Comma-separated concurrency levels for the sweep "
+                        "(e.g. '1,50'). Default: '1,50'"
+                    ),
+                },
+                "endpoint": {
+                    "type": "string",
+                    "description": (
+                        "vLLM endpoint URL. Auto-filled from CLI args if omitted."
+                    ),
+                },
+                "model": {
+                    "type": "string",
+                    "description": "Model name served by vLLM. Auto-filled from CLI args if omitted.",
+                },
+                "max_seconds": {
+                    "type": "integer",
+                    "description": "Maximum seconds per concurrency level. Default: 30",
+                    "default": 30,
+                },
+                "output_path": {
+                    "type": "string",
+                    "description": (
+                        "Path to save the GuideLLM JSON results. "
+                        "Default: ./benchmark_results/<profile>_<timestamp>.json"
+                    ),
+                },
+            },
+            "required": ["profile"],
+        },
+    },
+    {
+        "name": "analyze_trace",
+        "description": (
+            "Analyze a PyTorch profiler trace JSON file to extract kernel-level "
+            "performance statistics. Returns top kernels by GPU time, category "
+            "breakdown (attention, GEMM, normalization, etc.), and total GPU time. "
+            "Use this after collecting a trace to identify performance bottlenecks."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "trace_json_path": {
+                    "type": "string",
+                    "description": (
+                        "Path to the Chrome trace JSON file from PyTorch profiler. "
+                        "This is a local file path (on the machine running the agent)."
+                    ),
+                },
+                "top_n": {
+                    "type": "integer",
+                    "description": "Number of top kernels to return. Default: 20",
+                    "default": 20,
+                },
+            },
+            "required": ["trace_json_path"],
+        },
+    },
+    {
+        "name": "map_kernel",
+        "description": (
+            "Map a CUDA kernel name to its source code location in vLLM or PyTorch. "
+            "Returns the source file, function name, description, category, and whether "
+            "it is a PyTorch standard library kernel. Use this to understand what a hot "
+            "kernel does and where to look for optimization opportunities."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "kernel_name": {
+                    "type": "string",
+                    "description": (
+                        "CUDA kernel name from the profiler trace "
+                        "(e.g. 'flash_fwd_kernel', 'rms_norm_kernel')"
+                    ),
+                },
+            },
+            "required": ["kernel_name"],
+        },
+    },
+    {
+        "name": "fetch_vllm_logs",
+        "description": (
+            "Fetch and parse vLLM server logs from the pod. Runs REMOTELY on the pod "
+            "to collect log output, then parses it with 120+ regex patterns to extract "
+            "structured information: server config (vLLM version, non-default args), "
+            "engine config (dtype, quantization, TP/PP, CUDA graphs, chunked prefill), "
+            "compilation (attention backend, torch.compile time, CUDA graph capture), "
+            "memory (model memory, KV cache size, weights load time), "
+            "timing (engine init time), and warnings/errors. "
+            "IMPORTANT: Call this AFTER every benchmark to understand the server state. "
+            "Optionally specify pod_name to fetch logs from an experiment pod."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "log_source": {
+                    "type": "string",
+                    "description": (
+                        "How to collect logs. Options: "
+                        "'process' (default) reads /proc/1/fd/1 for stdout of vLLM process, "
+                        "'file' reads a specific log file path, "
+                        "'dmesg' reads kernel messages for OOM/GPU errors."
+                    ),
+                    "enum": ["process", "file", "dmesg"],
+                    "default": "process",
+                },
+                "log_path": {
+                    "type": "string",
+                    "description": (
+                        "Path to log file on the pod (only used when log_source='file'). "
+                        "Default: /tmp/vllm.log"
+                    ),
+                },
+                "tail_lines": {
+                    "type": "integer",
+                    "description": "Number of recent log lines to fetch. Default: 200",
+                    "default": 200,
+                },
+                "pod_name": {
+                    "type": "string",
+                    "description": (
+                        "Optional: name of an experiment pod to fetch logs from "
+                        "(created by create_vllm_pod). If omitted, uses the baseline pod."
+                    ),
+                },
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "read_benchmark_results",
+        "description": (
+            "Read and parse a GuideLLM benchmark results JSON file from a previous "
+            "run_benchmark call. Returns structured metrics per concurrency level: "
+            "request totals (successful/errored), output tokens/sec, TTFT, ITL, TPOT "
+            "with P50/P95/P99 percentiles, and request latency. "
+            "Use this to review detailed metrics from a completed benchmark. "
+            "The file path is shown in run_benchmark output as 'Results saved to: ...'."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "results_path": {
+                    "type": "string",
+                    "description": "Path to the GuideLLM JSON results file (local path).",
+                },
+            },
+            "required": ["results_path"],
+        },
+    },
+    {
+        "name": "compare_benchmarks",
+        "description": (
+            "Compare two benchmark runs to detect performance regressions or improvements. "
+            "Takes paths to two GuideLLM JSON result files (baseline and current), "
+            "extracts key metrics from each, and compares them with a configurable "
+            "threshold (default 2%). Reports per-metric changes with direction "
+            "(improvement/regression/neutral), accounting for metric directionality "
+            "(higher throughput = better, lower latency = better). "
+            "Use this after applying a tuning change to verify the impact."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "baseline_path": {
+                    "type": "string",
+                    "description": "Path to the baseline GuideLLM JSON results file.",
+                },
+                "current_path": {
+                    "type": "string",
+                    "description": "Path to the current (post-tuning) GuideLLM JSON results file.",
+                },
+                "threshold": {
+                    "type": "number",
+                    "description": (
+                        "Threshold for flagging a change as regression/improvement, "
+                        "as a fraction (e.g. 0.02 = 2%). Default: 0.02"
+                    ),
+                    "default": 0.02,
+                },
+            },
+            "required": ["baseline_path", "current_path"],
+        },
+    },
+    {
+        "name": "check_preemptions",
+        "description": (
+            "Query the vLLM Prometheus /metrics endpoint and return the preemption count. "
+            "Preemptions happen when vLLM evicts KV cache entries under memory pressure, "
+            "which severely hurts latency and throughput. If preemptions are occurring, "
+            "further tuning is unlikely to help — the workload exceeds GPU memory capacity. "
+            "Call this AFTER each benchmark to detect preemptions early."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "endpoint": {
+                    "type": "string",
+                    "description": (
+                        "vLLM endpoint URL to query. If omitted, uses the baseline endpoint. "
+                        "For experiment pods, pass the endpoint returned by create_vllm_pod."
+                    ),
+                },
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "create_vllm_pod",
+        "description": (
+            "Create a new experiment pod from the pod template with extra vLLM CLI args. "
+            "The pod is created in the configured namespace, waits for readiness, and "
+            "a port-forward is set up automatically. Returns the pod name and endpoint URL "
+            "that can be passed to run_benchmark. Use this to test tuning parameters without "
+            "modifying the baseline pod."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "vllm_args": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Extra vLLM CLI args to add to the pod's launch command. "
+                        'e.g. ["--enable-chunked-prefill", "--gpu-memory-utilization", "0.95"]'
+                    ),
+                },
+            },
+            "required": ["vllm_args"],
+        },
+    },
+    {
+        "name": "delete_vllm_pod",
+        "description": (
+            "Delete an experiment pod created by create_vllm_pod and clean up its "
+            "port-forward. Call this after benchmarking an experiment pod to free resources."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "pod_name": {
+                    "type": "string",
+                    "description": "Name of the experiment pod to delete (returned by create_vllm_pod).",
+                },
+            },
+            "required": ["pod_name"],
+        },
+    },
+    {
+        "name": "done",
+        "description": (
+            "Signal that the tuning session is complete. Call this when you have "
+            "achieved the performance target, exhausted viable tuning options, "
+            "or want to report final results. Provide a summary of actions taken "
+            "and results achieved."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "summary": {
+                    "type": "string",
+                    "description": (
+                        "Summary of what was done: tunings applied, benchmarks run, "
+                        "performance changes observed, and final recommendations."
+                    ),
+                },
+                "success": {
+                    "type": "boolean",
+                    "description": "Whether the performance target was achieved",
+                },
+            },
+            "required": ["summary", "success"],
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Handler implementations
+# ---------------------------------------------------------------------------
+
+
+def _handle_run_command(
+    args: dict,
+    executor: RemoteExecutor,
+    command_history: list[dict],
+) -> ToolResult:
+    """Execute a shell command on the vLLM host/pod."""
+    command = args["command"]
+    timeout = args.get("timeout", 60)
+
+    result = executor.run(command, timeout=timeout)
+
+    command_history.append(
+        {
+            "tool": "run_command",
+            "command": command,
+            "success": result.success,
+            "output": result.output[:2000],
+        }
+    )
+
+    return ToolResult(
+        tool="run_command",
+        success=result.success,
+        output=result.output,
+        error=result.stderr if not result.success else None,
+    )
+
+
+def _handle_read_file(
+    args: dict,
+    executor: RemoteExecutor,
+    command_history: list[dict],
+) -> ToolResult:
+    """Read a file from the vLLM host/pod."""
+    path = args["path"]
+
+    result = executor.read_file(path)
+
+    command_history.append(
+        {
+            "tool": "read_file",
+            "path": path,
+            "success": result.success,
+        }
+    )
+
+    return ToolResult(
+        tool="read_file",
+        success=result.success,
+        output=result.output,
+        error=result.stderr if not result.success else None,
+    )
+
+
+def _handle_write_file(
+    args: dict,
+    executor: RemoteExecutor,
+    command_history: list[dict],
+) -> ToolResult:
+    """Write content to a file on the vLLM host/pod."""
+    path = args["path"]
+    content = args["content"]
+
+    result = executor.write_file(path, content)
+
+    command_history.append(
+        {
+            "tool": "write_file",
+            "path": path,
+            "success": result.success,
+        }
+    )
+
+    return ToolResult(
+        tool="write_file",
+        success=result.success,
+        output=result.output,
+        error=result.stderr if not result.success else None,
+    )
+
+
+def _extract_guidellm_metrics(bench_data: dict) -> str:
+    """Extract structured metrics from GuideLLM JSON output.
+
+    Returns a human-readable summary of key performance metrics from each
+    benchmark run (one per concurrency level).
+    """
+    lines = ["=== GUIDELLM METRICS SUMMARY ==="]
+
+    benchmarks = bench_data.get("benchmarks", [])
+    if not benchmarks:
+        return "No benchmark data found in JSON output."
+
+    for i, bench in enumerate(benchmarks):
+        config = bench.get("config", {})
+        strategy = config.get("strategy", {})
+        conc = strategy.get("max_concurrency", strategy.get("worker_count", "?"))
+        lines.append(f"\n--- Concurrency: {conc} ---")
+
+        metrics = bench.get("metrics", {})
+
+        # Request totals
+        totals = metrics.get("request_totals", {})
+        successful = totals.get("successful", 0)
+        errored = totals.get("errored", 0)
+        total = totals.get("total", 0)
+        lines.append(
+            f"  Requests: {successful} successful, {errored} errored, {total} total"
+        )
+        if total > 0:
+            lines.append(f"  Success Rate: {successful / total * 100:.1f}%")
+
+        if successful == 0:
+            lines.append(
+                "  WARNING: No successful requests — metrics below will be zeros."
+            )
+            lines.append("  → Check vLLM logs for errors (model loading, OOM, etc.)")
+
+        # Throughput
+        def _stat_line(label, stat_dict, keys=("mean", "median")):
+            """Format a statistics dict into a readable line."""
+            if not stat_dict:
+                return f"  {label}: N/A"
+            # Look for 'successful' sub-dict first (GuideLLM v0.5 format)
+            d = stat_dict.get("successful", stat_dict)
+            parts = []
+            for k in keys:
+                v = d.get(k)
+                if v is not None:
+                    parts.append(f"{k}={v:.2f}")
+            # Add percentiles if present
+            pcts = d.get("percentiles", {})
+            for p in ("p50", "p95", "p99"):
+                v = pcts.get(p)
+                if v is not None:
+                    parts.append(f"{p}={v:.2f}")
+            return f"  {label}: {', '.join(parts)}" if parts else f"  {label}: N/A"
+
+        lines.append(
+            _stat_line("Output Tokens/sec", metrics.get("output_tokens_per_second"))
+        )
+        lines.append(
+            _stat_line("Prompt Tokens/sec", metrics.get("prompt_tokens_per_second"))
+        )
+        lines.append(_stat_line("Total Tokens/sec", metrics.get("tokens_per_second")))
+        lines.append(_stat_line("TTFT (ms)", metrics.get("time_to_first_token_ms")))
+        lines.append(_stat_line("ITL (ms)", metrics.get("inter_token_latency_ms")))
+        lines.append(_stat_line("TPOT (ms)", metrics.get("time_per_output_token_ms")))
+        lines.append(_stat_line("Request Latency (s)", metrics.get("request_latency")))
+        lines.append(_stat_line("Requests/sec", metrics.get("requests_per_second")))
+
+        # Duration
+        duration = bench.get("duration")
+        if duration is not None:
+            lines.append(f"  Duration: {duration:.1f}s")
+
+    return "\n".join(lines)
+
+
+def _handle_run_benchmark(
+    args: dict,
+    _executor: RemoteExecutor,
+    command_history: list[dict],
+) -> ToolResult:
+    """Run a GuideLLM benchmark from the LOCAL machine against the vLLM endpoint.
+
+    This does NOT run on the remote pod/host -- it runs locally using subprocess
+    because GuideLLM sends HTTP requests to the vLLM endpoint.
+    """
+    profile_name = args["profile"]
+    endpoint = args["endpoint"]
+    model = args["model"]
+    max_seconds = args.get("max_seconds", 30)
+    concurrency = args.get(
+        "concurrency", ",".join(str(c) for c in DEFAULT_CONCURRENCY_LEVELS)
+    )
+
+    if profile_name not in BENCHMARK_PROFILES:
+        return ToolResult(
+            tool="run_benchmark",
+            success=False,
+            output="",
+            error=f"Unknown profile '{profile_name}'. Choose from: {list(BENCHMARK_PROFILES.keys())}",
+        )
+
+    profile = BENCHMARK_PROFILES[profile_name]
+
+    # Build output path
+    import datetime
+
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_path = (
+        args.get("output_path")
+        or f"./benchmark_results/{profile_name}_{timestamp}.json"
+    )
+
+    # Ensure output directory exists
+    import os
+
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+
+    # Build GuideLLM command (runs locally, targets the vLLM endpoint)
+    # Target URL must end with /v1 for OpenAI-compatible API
+    target_url = endpoint.rstrip("/")
+    if not target_url.endswith("/v1"):
+        target_url += "/v1"
+
+    # Derive HuggingFace processor name from model path
+    # e.g. "/models/facebook/opt-125m" -> "facebook/opt-125m"
+    processor = args.get("processor", model)
+    if processor.startswith("/models/"):
+        processor = processor[len("/models/") :]
+
+    # Determine request type: chat/instruct models use chat_completions,
+    # base/causal models (opt, gpt2, etc.) need text_completions.
+    # Auto-detect from model name, with explicit override via request_type arg.
+    request_type = args.get("request_type")
+    if not request_type:
+        model_lower = model.lower()
+        _CHAT_INDICATORS = ("chat", "instruct", "it-", "-it", "rlhf")
+        if any(ind in model_lower for ind in _CHAT_INDICATORS):
+            request_type = "chat_completions"
+        else:
+            request_type = "text_completions"
+
+    guidellm_cmd = [
+        sys.executable,
+        "-m",
+        "guidellm",
+        "benchmark",
+        "run",
+        f"--target={target_url}",
+        f"--model={model}",
+        f"--processor={processor}",
+        "--rate-type=concurrent",
+        f"--max-seconds={max_seconds}",
+        f"--rate={concurrency}",
+        f"--output-path={output_path}",
+        f"--request-type={request_type}",
+        "--processor-args",
+        '{"trust-remote-code":"true"}',
+        "--data",
+        profile["data_flag"],
+    ]
+
+    command_str = " ".join(guidellm_cmd)
+
+    command_history.append(
+        {
+            "tool": "run_benchmark",
+            "profile": profile_name,
+            "concurrency": concurrency,
+            "endpoint": endpoint,
+            "model": model,
+            "command": command_str,
+        }
+    )
+
+    try:
+        # GuideLLM can take a long time; allow up to 30 minutes
+        bench_timeout = max(max_seconds * len(concurrency.split(",")) + 120, 600)
+        result = subprocess.run(
+            guidellm_cmd,
+            capture_output=True,
+            text=True,
+            timeout=bench_timeout,
+        )
+        stdout = result.stdout.replace("\r\n", "\n").replace("\r", "\n")
+        stderr = result.stderr.replace("\r\n", "\n").replace("\r", "\n")
+
+        if result.returncode == 0:
+            # Try to read and summarize the JSON output
+            summary_parts = [
+                f"Profile: {profile_name} ({profile['description']})",
+                f"Concurrency levels: {concurrency}",
+                f"Max seconds per level: {max_seconds}",
+                f"Results saved to: {output_path}",
+            ]
+
+            # Parse GuideLLM JSON and extract structured metrics
+            if os.path.exists(output_path):
+                try:
+                    with open(output_path, "r") as f:
+                        bench_data = json.load(f)
+                    metrics_summary = _extract_guidellm_metrics(bench_data)
+                    summary_parts.append("")
+                    summary_parts.append(metrics_summary)
+                except (json.JSONDecodeError, OSError) as e:
+                    summary_parts.append(f"(Could not parse results JSON: {e})")
+
+            # Append last 2000 chars of stdout for context
+            summary_parts.append("")
+            summary_parts.append("--- GuideLLM stdout (last 2000 chars) ---")
+            summary_parts.append(stdout[-2000:] if len(stdout) > 2000 else stdout)
+
+            output_text = "\n".join(summary_parts)
+        else:
+            output_text = (
+                f"GuideLLM exited with code {result.returncode}\n"
+                f"stdout:\n{stdout[-2000:]}\n"
+                f"stderr:\n{stderr[-2000:]}"
+            )
+
+        command_history[-1]["success"] = result.returncode == 0
+
+        return ToolResult(
+            tool="run_benchmark",
+            success=result.returncode == 0,
+            output=output_text,
+            error=stderr if result.returncode != 0 else None,
+        )
+
+    except subprocess.TimeoutExpired:
+        command_history[-1]["success"] = False
+        return ToolResult(
+            tool="run_benchmark",
+            success=False,
+            output="",
+            error=f"GuideLLM timed out after {bench_timeout}s",
+        )
+    except FileNotFoundError:
+        command_history[-1]["success"] = False
+        return ToolResult(
+            tool="run_benchmark",
+            success=False,
+            output="",
+            error=(
+                "GuideLLM is not installed or not on PATH. "
+                "Install with: pip install guidellm"
+            ),
+        )
+    except Exception as e:
+        command_history[-1]["success"] = False
+        return ToolResult(
+            tool="run_benchmark",
+            success=False,
+            output="",
+            error=f"Failed to run GuideLLM: {e}",
+        )
+
+
+def _handle_analyze_trace(
+    args: dict,
+    _executor: RemoteExecutor,
+    command_history: list[dict],
+) -> ToolResult:
+    """Analyze a PyTorch profiler trace JSON file.
+
+    Loads the Chrome trace from disk and delegates to
+    ``analysis.trace_analyzer.analyze_trace``. Falls back to a basic JSON
+    parse if the analyzer cannot be imported.
+    """
+    trace_path = args["trace_json_path"]
+    top_n = args.get("top_n", 20)
+
+    command_history.append(
+        {
+            "tool": "analyze_trace",
+            "trace_json_path": trace_path,
+        }
+    )
+
+    try:
+        from .analysis.trace_analyzer import analyze_trace as analyze_trace_fn
+
+        if not os.path.exists(trace_path):
+            command_history[-1]["success"] = False
+            return ToolResult(
+                tool="analyze_trace",
+                success=False,
+                output="",
+                error=f"Trace file not found: {trace_path}",
+            )
+        with open(trace_path, encoding="utf-8") as fh:
+            trace_data = json.load(fh)
+        result = analyze_trace_fn(trace_data, top_n=top_n)
+        command_history[-1]["success"] = True
+        return ToolResult(
+            tool="analyze_trace",
+            success=True,
+            output=json.dumps(result, indent=2, default=str),
+        )
+    except (ImportError, AttributeError, json.JSONDecodeError, OSError):
+        pass
+
+    # Fallback: basic trace parsing
+    try:
+        if not os.path.exists(trace_path):
+            command_history[-1]["success"] = False
+            return ToolResult(
+                tool="analyze_trace",
+                success=False,
+                output="",
+                error=f"Trace file not found: {trace_path}",
+            )
+
+        with open(trace_path, "r") as f:
+            trace_data = json.load(f)
+
+        # Basic Chrome trace event parsing
+        events = (
+            trace_data
+            if isinstance(trace_data, list)
+            else trace_data.get("traceEvents", [])
+        )
+        gpu_events = [
+            e
+            for e in events
+            if isinstance(e, dict)
+            and e.get("cat") in ("kernel", "gpu_memcpy", "cuda_runtime")
+            and e.get("dur", 0) > 0
+        ]
+
+        # Aggregate by kernel name
+        kernel_stats: dict[str, dict] = {}
+        for e in gpu_events:
+            name = e.get("name", "unknown")
+            dur_us = e.get("dur", 0)
+            if name not in kernel_stats:
+                kernel_stats[name] = {
+                    "count": 0,
+                    "total_dur_us": 0,
+                    "min_dur_us": dur_us,
+                    "max_dur_us": dur_us,
+                }
+            stats = kernel_stats[name]
+            stats["count"] += 1
+            stats["total_dur_us"] += dur_us
+            stats["min_dur_us"] = min(stats["min_dur_us"], dur_us)
+            stats["max_dur_us"] = max(stats["max_dur_us"], dur_us)
+
+        # Sort by total duration and take top N
+        sorted_kernels = sorted(
+            kernel_stats.items(), key=lambda x: x[1]["total_dur_us"], reverse=True
+        )
+        top_kernels = [
+            {
+                "kernel": name,
+                **stats,
+                "avg_dur_us": round(stats["total_dur_us"] / stats["count"], 2),
+            }
+            for name, stats in sorted_kernels[:top_n]
+        ]
+
+        total_gpu_time_us = sum(s["total_dur_us"] for s in kernel_stats.values())
+
+        result = {
+            "trace_file": trace_path,
+            "total_events": len(events),
+            "gpu_events": len(gpu_events),
+            "unique_kernels": len(kernel_stats),
+            "total_gpu_time_us": total_gpu_time_us,
+            "total_gpu_time_ms": round(total_gpu_time_us / 1000, 2),
+            "top_kernels": top_kernels,
+            "note": "Basic fallback parser (trace_analyzer module not yet populated)",
+        }
+
+        command_history[-1]["success"] = True
+        return ToolResult(
+            tool="analyze_trace",
+            success=True,
+            output=json.dumps(result, indent=2),
+        )
+
+    except json.JSONDecodeError as e:
+        command_history[-1]["success"] = False
+        return ToolResult(
+            tool="analyze_trace",
+            success=False,
+            output="",
+            error=f"Failed to parse trace JSON: {e}",
+        )
+    except Exception as e:
+        command_history[-1]["success"] = False
+        return ToolResult(
+            tool="analyze_trace",
+            success=False,
+            output="",
+            error=f"Failed to analyze trace: {e}",
+        )
+
+
+def _handle_map_kernel(
+    args: dict,
+    _executor: RemoteExecutor,
+    command_history: list[dict],
+) -> ToolResult:
+    """Map a CUDA kernel name to its source code location.
+
+    Delegates to agent.analysis.kernel_mapper.  Falls back to a stub
+    response if the module is not yet populated.
+    """
+    kernel_name = args["kernel_name"]
+
+    command_history.append(
+        {
+            "tool": "map_kernel",
+            "kernel_name": kernel_name,
+        }
+    )
+
+    try:
+        from .analysis import kernel_mapper
+
+        if hasattr(kernel_mapper, "find_kernel_mapping"):
+            mapping = kernel_mapper.find_kernel_mapping(kernel_name)
+            is_stdlib = False
+            if hasattr(kernel_mapper, "is_pytorch_stdlib"):
+                is_stdlib = kernel_mapper.is_pytorch_stdlib(kernel_name)
+            result = {
+                "kernel_name": kernel_name,
+                "mapping": mapping,
+                "is_pytorch_stdlib": is_stdlib,
+            }
+            command_history[-1]["success"] = True
+            return ToolResult(
+                tool="map_kernel",
+                success=True,
+                output=json.dumps(result, indent=2, default=str),
+            )
+    except (ImportError, AttributeError):
+        pass
+
+    # Fallback: pattern-based heuristic when the full mapper is not available
+    result = _fallback_kernel_mapping(kernel_name)
+    command_history[-1]["success"] = True
+    return ToolResult(
+        tool="map_kernel",
+        success=True,
+        output=json.dumps(result, indent=2),
+    )
+
+
+def _fallback_kernel_mapping(kernel_name: str) -> dict:
+    """Simple heuristic kernel mapping when kernel_mapper is not populated."""
+    name_lower = kernel_name.lower()
+
+    # Pattern-based classification
+    patterns = [
+        (
+            ["flash_fwd", "flash_bwd", "flash_attn"],
+            "attention",
+            "Flash Attention kernel",
+            "vllm/attention/",
+        ),
+        (
+            ["paged_attention", "paged_attn"],
+            "attention",
+            "PagedAttention kernel",
+            "vllm/attention/",
+        ),
+        (["fmha"], "attention", "Fused multi-head attention", "vllm/attention/"),
+        (
+            ["cutlass", "gemm", "cublas", "matmul", "sgemm", "hgemm"],
+            "linear/gemm",
+            "Matrix multiplication kernel",
+            "torch or cutlass",
+        ),
+        (
+            ["rms_norm", "rmsnorm"],
+            "normalization",
+            "RMS normalization kernel",
+            "vllm/model_executor/layers/",
+        ),
+        (
+            ["layer_norm", "layernorm"],
+            "normalization",
+            "Layer normalization kernel",
+            "torch/nn/",
+        ),
+        (
+            ["silu", "gelu", "relu", "swiglu"],
+            "activation",
+            "Activation function kernel",
+            "vllm/model_executor/layers/",
+        ),
+        (
+            ["rotary", "rope"],
+            "positional_encoding",
+            "Rotary positional embedding kernel",
+            "vllm/model_executor/layers/",
+        ),
+        (["memcpy", "memset"], "memory", "Memory operation", "CUDA runtime"),
+        (
+            ["nccl", "allreduce", "allgather"],
+            "communication",
+            "Collective communication kernel",
+            "NCCL",
+        ),
+        (["softmax"], "attention", "Softmax kernel", "torch or custom"),
+        (
+            ["elementwise", "binary", "unary"],
+            "elementwise",
+            "Elementwise operation",
+            "torch",
+        ),
+        (
+            ["topk", "sampling", "argmax"],
+            "sampling",
+            "Sampling/selection kernel",
+            "vllm/model_executor/layers/sampler",
+        ),
+        (
+            ["quantize", "dequantize", "fp8", "awq", "gptq"],
+            "quantization",
+            "Quantization kernel",
+            "vllm/model_executor/layers/quantization/",
+        ),
+    ]
+
+    for keywords, category, description, source_hint in patterns:
+        if any(kw in name_lower for kw in keywords):
+            return {
+                "kernel_name": kernel_name,
+                "category": category,
+                "description": description,
+                "source_hint": source_hint,
+                "is_pytorch_stdlib": any(
+                    kw in name_lower for kw in ["cublas", "memcpy", "memset", "nccl"]
+                ),
+                "note": "Heuristic mapping (kernel_mapper module not yet populated)",
+            }
+
+    return {
+        "kernel_name": kernel_name,
+        "category": "unknown",
+        "description": "Kernel not recognized by heuristic mapper",
+        "source_hint": "unknown",
+        "is_pytorch_stdlib": False,
+        "note": "Heuristic mapping (kernel_mapper module not yet populated)",
+    }
+
+
+def _handle_fetch_vllm_logs(
+    args: dict,
+    executor: RemoteExecutor,
+    command_history: list[dict],
+) -> ToolResult:
+    """Fetch vLLM logs from the pod and parse them into structured data.
+
+    Runs remotely on the pod to collect log text, then applies the vLLM log
+    parser (120+ regex patterns) to extract server config, engine config,
+    compilation, memory, timing, and warnings.
+    """
+    log_source = args.get("log_source", "process")
+    tail_lines = args.get("tail_lines", 200)
+
+    command_history.append(
+        {
+            "tool": "fetch_vllm_logs",
+            "log_source": log_source,
+            "tail_lines": tail_lines,
+        }
+    )
+
+    # Build the command to fetch logs from the pod
+    if log_source == "file":
+        log_path = args.get("log_path", "/tmp/vllm.log")
+        cmd = f"tail -{tail_lines} {log_path} 2>/dev/null || echo 'Log file not found: {log_path}'"
+    elif log_source == "dmesg":
+        cmd = f"dmesg | tail -{tail_lines} 2>/dev/null || echo 'dmesg not available'"
+    else:
+        # Default: try multiple log sources
+        cmd = (
+            f"(cat /proc/1/fd/1 2>/dev/null | tail -{tail_lines}) || "
+            f"(tail -{tail_lines} /tmp/vllm*.log 2>/dev/null) || "
+            f"(journalctl -u vllm --no-pager -n {tail_lines} 2>/dev/null) || "
+            f"echo 'No vLLM logs found. Try log_source=file with a specific path.'"
+        )
+
+    result = executor.run(cmd, timeout=30)
+
+    if not result.success:
+        command_history[-1]["success"] = False
+        return ToolResult(
+            tool="fetch_vllm_logs",
+            success=False,
+            output="",
+            error=f"Failed to fetch logs: {result.stderr}",
+        )
+
+    raw_logs = result.stdout
+
+    # Also fetch current vLLM launch args
+    cmdline_result = executor.run(
+        "cat /proc/1/cmdline 2>/dev/null | tr '\\0' ' '", timeout=10
+    )
+    cmdline = cmdline_result.stdout.strip() if cmdline_result.success else ""
+
+    # Parse logs with the structured parser
+    try:
+        from .analysis.vllm_log_parser import parse_vllm_log
+
+        parsed = parse_vllm_log(raw_logs)
+    except Exception as e:
+        parsed = {"parse_error": str(e)}
+
+    # Add cmdline to parsed result
+    if cmdline:
+        parsed.setdefault("server_config", {})["cmdline"] = cmdline
+
+    # Build output
+    output_parts = ["=== PARSED VLLM LOG ANALYSIS ==="]
+
+    for section, data in parsed.items():
+        if section == "warnings_errors":
+            if data:
+                output_parts.append(f"\n--- Warnings/Errors ({len(data)} found) ---")
+                for w in data[:20]:  # Limit to 20
+                    output_parts.append(f"  {w[:200]}")
+        elif isinstance(data, dict):
+            output_parts.append(f"\n--- {section.replace('_', ' ').title()} ---")
+            for k, v in data.items():
+                if k == "non_default_args" and isinstance(v, dict):
+                    output_parts.append(f"  {k}:")
+                    for ak, av in v.items():
+                        output_parts.append(f"    {ak}: {av}")
+                else:
+                    output_parts.append(f"  {k}: {v}")
+
+    output_parts.append(
+        f"\n--- Raw Log Tail ({min(tail_lines, len(raw_logs.splitlines()))} lines) ---"
+    )
+    # Include last 50 lines of raw logs for context
+    raw_tail = "\n".join(raw_logs.splitlines()[-50:])
+    output_parts.append(raw_tail)
+
+    output_text = "\n".join(output_parts)
+    command_history[-1]["success"] = True
+    command_history[-1]["parsed_sections"] = list(parsed.keys())
+
+    return ToolResult(
+        tool="fetch_vllm_logs",
+        success=True,
+        output=output_text,
+    )
+
+
+def _extract_flat_metrics(bench_data: dict) -> list[dict]:
+    """Extract flat metric dicts per concurrency level from GuideLLM JSON.
+
+    Returns a list of dicts, one per benchmark (concurrency level), with
+    flat key-value pairs suitable for comparison.
+    """
+    results = []
+    benchmarks = bench_data.get("benchmarks", [])
+
+    for bench in benchmarks:
+        config = bench.get("config", {})
+        strategy = config.get("strategy", {})
+        conc = strategy.get("max_concurrency", strategy.get("worker_count", 0))
+        metrics = bench.get("metrics", {})
+
+        flat: dict = {"concurrency": conc}
+
+        # Request totals
+        totals = metrics.get("request_totals", {})
+        flat["successful_requests"] = totals.get("successful", 0)
+        flat["errored_requests"] = totals.get("errored", 0)
+        flat["total_requests"] = totals.get("total", 0)
+
+        # Extract mean and percentiles from each metric
+        metric_keys = [
+            ("output_tokens_per_second", "output_tok/sec"),
+            ("prompt_tokens_per_second", "prompt_tok/sec"),
+            ("tokens_per_second", "total_tok/sec"),
+            ("time_to_first_token_ms", "ttft"),
+            ("inter_token_latency_ms", "itl"),
+            ("time_per_output_token_ms", "tpot"),
+            ("request_latency", "request_latency"),
+            ("requests_per_second", "requests/sec"),
+        ]
+
+        for src_key, dst_prefix in metric_keys:
+            stat_dict = metrics.get(src_key, {})
+            d = stat_dict.get("successful", stat_dict)
+            if isinstance(d, dict):
+                for stat in ("mean", "median"):
+                    v = d.get(stat)
+                    if v is not None:
+                        flat[f"{dst_prefix}_{stat}"] = round(v, 4)
+                pcts = d.get("percentiles", {})
+                for p in ("p50", "p95", "p99"):
+                    v = pcts.get(p)
+                    if v is not None:
+                        flat[f"{dst_prefix}_{p}"] = round(v, 4)
+
+        flat["duration_s"] = bench.get("duration")
+        results.append(flat)
+
+    return results
+
+
+def _handle_read_benchmark_results(
+    args: dict,
+    _executor: RemoteExecutor,
+    command_history: list[dict],
+) -> ToolResult:
+    """Read and parse a GuideLLM benchmark JSON file into structured metrics."""
+    import os
+
+    results_path = args["results_path"]
+
+    command_history.append(
+        {
+            "tool": "read_benchmark_results",
+            "results_path": results_path,
+        }
+    )
+
+    if not os.path.exists(results_path):
+        command_history[-1]["success"] = False
+        return ToolResult(
+            tool="read_benchmark_results",
+            success=False,
+            output="",
+            error=f"Results file not found: {results_path}",
+        )
+
+    try:
+        with open(results_path, "r") as f:
+            bench_data = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        command_history[-1]["success"] = False
+        return ToolResult(
+            tool="read_benchmark_results",
+            success=False,
+            output="",
+            error=f"Failed to parse JSON: {e}",
+        )
+
+    # Extract structured metrics
+    flat_metrics = _extract_flat_metrics(bench_data)
+
+    # Also get the GuideLLM summary
+    guidellm_summary = _extract_guidellm_metrics(bench_data)
+
+    # Build output
+    output_parts = [guidellm_summary, ""]
+    output_parts.append("=== FLAT METRICS PER CONCURRENCY (for compare_benchmarks) ===")
+    for fm in flat_metrics:
+        output_parts.append(json.dumps(fm, indent=2))
+
+    output_text = "\n".join(output_parts)
+    command_history[-1]["success"] = True
+
+    return ToolResult(
+        tool="read_benchmark_results",
+        success=True,
+        output=output_text,
+    )
+
+
+def _handle_compare_benchmarks(
+    args: dict,
+    _executor: RemoteExecutor,
+    command_history: list[dict],
+) -> ToolResult:
+    """Compare two GuideLLM benchmark runs and detect regressions/improvements."""
+    import os
+
+    baseline_path = args["baseline_path"]
+    current_path = args["current_path"]
+    threshold = args.get("threshold", 0.02)
+
+    command_history.append(
+        {
+            "tool": "compare_benchmarks",
+            "baseline_path": baseline_path,
+            "current_path": current_path,
+            "threshold": threshold,
+        }
+    )
+
+    # Load both files
+    for path, label in [(baseline_path, "Baseline"), (current_path, "Current")]:
+        if not os.path.exists(path):
+            command_history[-1]["success"] = False
+            return ToolResult(
+                tool="compare_benchmarks",
+                success=False,
+                output="",
+                error=f"{label} file not found: {path}",
+            )
+
+    try:
+        with open(baseline_path, "r") as f:
+            baseline_data = json.load(f)
+        with open(current_path, "r") as f:
+            current_data = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        command_history[-1]["success"] = False
+        return ToolResult(
+            tool="compare_benchmarks",
+            success=False,
+            output="",
+            error=f"Failed to parse JSON: {e}",
+        )
+
+    # Extract flat metrics
+    baseline_metrics_list = _extract_flat_metrics(baseline_data)
+    current_metrics_list = _extract_flat_metrics(current_data)
+
+    if not baseline_metrics_list or not current_metrics_list:
+        command_history[-1]["success"] = False
+        return ToolResult(
+            tool="compare_benchmarks",
+            success=False,
+            output="",
+            error="One or both benchmark files contain no benchmark data.",
+        )
+
+    # Import regression detector
+    try:
+        from .analysis.regression import detect_regression
+    except ImportError:
+        # Inline minimal comparison if module not available
+        detect_regression = None
+
+    output_parts = ["=== BENCHMARK COMPARISON ==="]
+    output_parts.append(f"Baseline: {baseline_path}")
+    output_parts.append(f"Current:  {current_path}")
+    output_parts.append(f"Threshold: {threshold * 100:.1f}%")
+
+    # Compare each concurrency level
+    baseline_by_conc = {m.get("concurrency", 0): m for m in baseline_metrics_list}
+    current_by_conc = {m.get("concurrency", 0): m for m in current_metrics_list}
+
+    common_conc = sorted(set(baseline_by_conc.keys()) & set(current_by_conc.keys()))
+
+    if not common_conc:
+        # Fall back to comparing first entry from each
+        output_parts.append("\nNo common concurrency levels. Comparing first entries.")
+        common_conc = [baseline_metrics_list[0].get("concurrency", 0)]
+        current_by_conc[common_conc[0]] = current_metrics_list[0]
+
+    all_comparisons = []
+    for conc in common_conc:
+        baseline_flat = baseline_by_conc.get(conc, baseline_metrics_list[0])
+        current_flat = current_by_conc.get(conc, current_metrics_list[0])
+
+        output_parts.append(f"\n--- Concurrency: {conc} ---")
+
+        if detect_regression is not None:
+            result = detect_regression(baseline_flat, current_flat, threshold=threshold)
+            if result.get("status") == "success":
+                output_parts.append(f"  Verdict: {result['summary']['verdict']}")
+                output_parts.append(f"  {result['message']}")
+
+                for comp in result.get("regressions", []):
+                    output_parts.append(
+                        f"  REGRESSION: {comp['metric']}: "
+                        f"{comp['baseline_value']} -> {comp['current_value']} "
+                        f"({comp['percent_change']:+.1f}%)"
+                    )
+                for comp in result.get("improvements", []):
+                    output_parts.append(
+                        f"  IMPROVED: {comp['metric']}: "
+                        f"{comp['baseline_value']} -> {comp['current_value']} "
+                        f"({comp['percent_change']:+.1f}%)"
+                    )
+                all_comparisons.append(result)
+            else:
+                output_parts.append(f"  Error: {result.get('message', 'unknown')}")
+        else:
+            # Manual comparison
+            for key in sorted(set(baseline_flat.keys()) & set(current_flat.keys())):
+                bv = baseline_flat[key]
+                cv = current_flat[key]
+                if (
+                    isinstance(bv, (int, float))
+                    and isinstance(cv, (int, float))
+                    and bv != 0
+                ):
+                    pct = ((cv - bv) / bv) * 100
+                    output_parts.append(f"  {key}: {bv} -> {cv} ({pct:+.1f}%)")
+
+    output_text = "\n".join(output_parts)
+    command_history[-1]["success"] = True
+
+    return ToolResult(
+        tool="compare_benchmarks",
+        success=True,
+        output=output_text,
+    )
+
+
+def _handle_check_preemptions(
+    args: dict,
+    _executor: RemoteExecutor,
+    command_history: list[dict],
+) -> ToolResult:
+    """Query vLLM /metrics endpoint for preemption count."""
+    import re
+    import urllib.error
+    import urllib.request
+
+    endpoint = args.get("endpoint", "").rstrip("/")
+    if not endpoint:
+        return ToolResult(
+            tool="check_preemptions",
+            success=False,
+            output="",
+            error="No endpoint provided and no default available. Pass endpoint explicitly.",
+        )
+
+    metrics_url = f"{endpoint}/metrics"
+
+    command_history.append(
+        {
+            "tool": "check_preemptions",
+            "endpoint": endpoint,
+        }
+    )
+
+    try:
+        req = urllib.request.Request(metrics_url, method="GET")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = resp.read().decode("utf-8")
+    except Exception as e:
+        command_history[-1]["success"] = False
+        return ToolResult(
+            tool="check_preemptions",
+            success=False,
+            output="",
+            error=f"Failed to fetch {metrics_url}: {e}",
+        )
+
+    # Parse preemption counter
+    preemption_count = 0.0
+    for line in body.splitlines():
+        if line.startswith("vllm:num_preemptions_total"):
+            m = re.search(r"}\s+([\d.eE+\-]+)", line)
+            if m:
+                preemption_count += float(m.group(1))
+
+    command_history[-1]["success"] = True
+    command_history[-1]["preemption_count"] = preemption_count
+
+    if preemption_count > 0:
+        output = (
+            f"WARNING: {int(preemption_count)} preemption(s) detected!\n"
+            f"vLLM is evicting KV cache entries under memory pressure.\n"
+            f"This means the workload exceeds available GPU memory for the current config.\n"
+            f"Further tuning is unlikely to help. Consider:\n"
+            f"  - Reducing max-num-seqs or max-num-batched-tokens\n"
+            f"  - Reducing max-model-len\n"
+            f"  - Using quantization to free memory\n"
+            f"  - If preemptions persist across configs, stop tuning and report findings."
+        )
+    else:
+        output = "No preemptions detected. KV cache pressure is within limits."
+
+    return ToolResult(
+        tool="check_preemptions",
+        success=True,
+        output=output,
+    )
+
+
+def _handle_create_vllm_pod(
+    args: dict,
+    _executor: RemoteExecutor,
+    command_history: list[dict],
+    *,
+    pod_manager: Optional[PodManager] = None,
+) -> ToolResult:
+    """Create a new experiment pod with extra vLLM CLI args."""
+    vllm_args = args["vllm_args"]
+
+    command_history.append(
+        {
+            "tool": "create_vllm_pod",
+            "vllm_args": vllm_args,
+        }
+    )
+
+    if pod_manager is None:
+        command_history[-1]["success"] = False
+        return ToolResult(
+            tool="create_vllm_pod",
+            success=False,
+            output="",
+            error="PodManager not configured. Use --pod-template and --oc-mode to enable pod management.",
+        )
+
+    try:
+        pod_name, endpoint = pod_manager.create_pod(vllm_args)
+        command_history[-1]["success"] = True
+        command_history[-1]["pod_name"] = pod_name
+        command_history[-1]["endpoint"] = endpoint
+        return ToolResult(
+            tool="create_vllm_pod",
+            success=True,
+            output=(
+                f"Experiment pod created successfully.\n"
+                f"  Pod name: {pod_name}\n"
+                f"  Endpoint: {endpoint}\n"
+                f"  vLLM args: {' '.join(vllm_args)}\n\n"
+                f'Use this endpoint when calling run_benchmark (pass endpoint="{endpoint}").\n'
+                f'Use pod_name="{pod_name}" with run_command or fetch_vllm_logs to inspect the pod.\n'
+                f'Call delete_vllm_pod(pod_name="{pod_name}") when done.'
+            ),
+        )
+    except Exception as e:
+        command_history[-1]["success"] = False
+        return ToolResult(
+            tool="create_vllm_pod",
+            success=False,
+            output="",
+            error=f"Failed to create experiment pod: {e}",
+        )
+
+
+def _handle_delete_vllm_pod(
+    args: dict,
+    _executor: RemoteExecutor,
+    command_history: list[dict],
+    *,
+    pod_manager: Optional[PodManager] = None,
+) -> ToolResult:
+    """Delete an experiment pod and clean up its port-forward."""
+    pod_name = args["pod_name"]
+
+    command_history.append(
+        {
+            "tool": "delete_vllm_pod",
+            "pod_name": pod_name,
+        }
+    )
+
+    if pod_manager is None:
+        command_history[-1]["success"] = False
+        return ToolResult(
+            tool="delete_vllm_pod",
+            success=False,
+            output="",
+            error="PodManager not configured.",
+        )
+
+    try:
+        pod_manager.delete_pod(pod_name)
+        command_history[-1]["success"] = True
+        return ToolResult(
+            tool="delete_vllm_pod",
+            success=True,
+            output=f"Pod {pod_name} deleted and port-forward cleaned up.",
+        )
+    except Exception as e:
+        command_history[-1]["success"] = False
+        return ToolResult(
+            tool="delete_vllm_pod",
+            success=False,
+            output="",
+            error=f"Failed to delete pod {pod_name}: {e}",
+        )
+
+
+def _handle_done(
+    args: dict,
+    _executor: RemoteExecutor,
+    command_history: list[dict],
+) -> ToolResult:
+    """Signal that the agent has completed its work."""
+    summary = args["summary"]
+    success = args.get("success", False)
+
+    command_history.append(
+        {
+            "tool": "done",
+            "summary": summary,
+            "success": success,
+        }
+    )
+
+    return ToolResult(
+        tool="done",
+        success=success,
+        output=summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch table
+# ---------------------------------------------------------------------------
+
+_TOOL_HANDLERS = {
+    "run_command": _handle_run_command,
+    "read_file": _handle_read_file,
+    "write_file": _handle_write_file,
+    "run_benchmark": _handle_run_benchmark,
+    "fetch_vllm_logs": _handle_fetch_vllm_logs,
+    "read_benchmark_results": _handle_read_benchmark_results,
+    "compare_benchmarks": _handle_compare_benchmarks,
+    "analyze_trace": _handle_analyze_trace,
+    "map_kernel": _handle_map_kernel,
+    "check_preemptions": _handle_check_preemptions,
+    "create_vllm_pod": _handle_create_vllm_pod,
+    "delete_vllm_pod": _handle_delete_vllm_pod,
+    "done": _handle_done,
+}
+
+# Handlers that accept pod_manager as a keyword argument
+_POD_MANAGER_HANDLERS = {"create_vllm_pod", "delete_vllm_pod"}
+
+# Handlers that accept an executor override via pod_name arg
+_POD_AWARE_HANDLERS = {"run_command", "fetch_vllm_logs"}
+
+
+def dispatch_tool(
+    name: str,
+    args: dict,
+    executor: RemoteExecutor,
+    command_history: Optional[list[dict]] = None,
+    *,
+    pod_manager: Optional[PodManager] = None,
+    namespace: Optional[str] = None,
+    kubeconfig: Optional[str] = None,
+) -> ToolResult:
+    """Route a tool call to the appropriate handler.
+
+    Parameters
+    ----------
+    name : str
+        Tool name (must match one of the keys in TOOL_DEFINITIONS).
+    args : dict
+        Tool input arguments from the Claude API response.
+    executor : RemoteExecutor
+        The configured executor (SSHExecutor or OcExecutor) for remote commands.
+    command_history : list[dict] or None
+        Mutable list to track command history across the agent session.
+        If None, a temporary list is used (history is discarded).
+    pod_manager : PodManager or None
+        Pod manager for create/delete pod operations.
+    namespace : str or None
+        OpenShift namespace (used to create temp OcExecutors for experiment pods).
+    kubeconfig : str or None
+        Kubeconfig path (used to create temp OcExecutors for experiment pods).
+
+    Returns
+    -------
+    ToolResult
+        Result of the tool execution.
+    """
+    if command_history is None:
+        command_history = []
+
+    handler = _TOOL_HANDLERS.get(name)
+    if handler is None:
+        return ToolResult(
+            tool=name,
+            success=False,
+            output="",
+            error=f"Unknown tool: '{name}'. Available tools: {list(_TOOL_HANDLERS.keys())}",
+        )
+
+    # For pod manager tools, pass pod_manager as keyword arg
+    if name in _POD_MANAGER_HANDLERS:
+        return handler(args, executor, command_history, pod_manager=pod_manager)
+
+    # For pod-aware tools, create a temp OcExecutor if pod_name is specified
+    target_executor = executor
+    pod_name = args.pop("pod_name", None) if name in _POD_AWARE_HANDLERS else None
+    if pod_name and namespace:
+        target_executor = OcExecutor(
+            namespace=namespace,
+            pod_name=pod_name,
+            kubeconfig=kubeconfig,
+        )
+
+    return handler(args, target_executor, command_history)
+
+
+# ---------------------------------------------------------------------------
+# Convenience: AgentTools class (higher-level wrapper, optional)
+# ---------------------------------------------------------------------------
+
+
+class AgentTools:
+    """Higher-level wrapper that bundles an executor with tool dispatch.
+
+    Provides a class-based interface similar to the original ai-perf-hackathon
+    AgentTools, but backed by the RemoteExecutor abstraction.
+    """
+
+    def __init__(
+        self,
+        executor: RemoteExecutor,
+        vllm_endpoint: str = "http://localhost:8000",
+        model_name: str = "",
+        pod_manager: Optional[PodManager] = None,
+        namespace: Optional[str] = None,
+        kubeconfig: Optional[str] = None,
+    ):
+        self.executor = executor
+        self.vllm_endpoint = vllm_endpoint
+        self.model_name = model_name
+        self.pod_manager = pod_manager
+        self.namespace = namespace
+        self.kubeconfig = kubeconfig
+        self.command_history: list[dict] = []
+
+    def get_tool_definitions(self) -> list[dict]:
+        """Return the tool definitions list for Claude's API."""
+        return TOOL_DEFINITIONS
+
+    def dispatch(self, name: str, args: dict) -> ToolResult:
+        """Dispatch a tool call, tracking history on this instance.
+
+        For run_benchmark, uses the agent-supplied endpoint if provided,
+        otherwise falls back to the CLI-provided baseline endpoint.
+        Model name is always filled from CLI args.
+        """
+        if name == "run_benchmark":
+            if "endpoint" not in args or not args.get("endpoint"):
+                args["endpoint"] = self.vllm_endpoint  # baseline default
+            args["model"] = self.model_name
+        elif name == "check_preemptions":
+            if "endpoint" not in args or not args.get("endpoint"):
+                args["endpoint"] = self.vllm_endpoint  # baseline default
+        return dispatch_tool(
+            name,
+            args,
+            self.executor,
+            self.command_history,
+            pod_manager=self.pod_manager,
+            namespace=self.namespace,
+            kubeconfig=self.kubeconfig,
+        )
+
+    # Convenience methods for direct (non-agent) use
+
+    def run_command(self, command: str, timeout: int = 60) -> ToolResult:
+        return self.dispatch("run_command", {"command": command, "timeout": timeout})
+
+    def read_file(self, path: str) -> ToolResult:
+        return self.dispatch("read_file", {"path": path})
+
+    def write_file(self, path: str, content: str) -> ToolResult:
+        return self.dispatch("write_file", {"path": path, "content": content})
+
+    def run_benchmark(
+        self,
+        profile: str,
+        endpoint: str,
+        model: str,
+        concurrency: Optional[str] = None,
+        max_seconds: int = 120,
+        output_path: Optional[str] = None,
+    ) -> ToolResult:
+        args: dict = {
+            "profile": profile,
+            "endpoint": endpoint,
+            "model": model,
+            "max_seconds": max_seconds,
+        }
+        if concurrency:
+            args["concurrency"] = concurrency
+        if output_path:
+            args["output_path"] = output_path
+        return self.dispatch("run_benchmark", args)
+
+    def analyze_trace(self, trace_json_path: str, top_n: int = 20) -> ToolResult:
+        return self.dispatch(
+            "analyze_trace", {"trace_json_path": trace_json_path, "top_n": top_n}
+        )
+
+    def map_kernel(self, kernel_name: str) -> ToolResult:
+        return self.dispatch("map_kernel", {"kernel_name": kernel_name})
+
+    def done(self, summary: str, success: bool = False) -> ToolResult:
+        return self.dispatch("done", {"summary": summary, "success": success})

--- a/auto_tune_vllm/cli/agent_cmd.py
+++ b/auto_tune_vllm/cli/agent_cmd.py
@@ -1,0 +1,102 @@
+"""Typer command for the Claude-driven agentic vLLM tuner."""
+
+from __future__ import annotations
+
+import os
+from argparse import Namespace
+from typing import Optional
+
+import typer
+from rich.console import Console
+
+console = Console()
+
+
+def agent_command(
+    vllm_endpoint: str = typer.Option(
+        ..., "--vllm-endpoint", help="URL of the running vLLM server"
+    ),
+    model: str = typer.Option(..., "--model", help="Model served by vLLM"),
+    vllm_host: Optional[str] = typer.Option(
+        None, "--vllm-host", help="SSH hostname (required unless --oc-mode)"
+    ),
+    api_key: Optional[str] = typer.Option(
+        None, "--api-key", help="Anthropic API key (default: $ANTHROPIC_API_KEY)"
+    ),
+    claude_model: str = typer.Option(
+        "sonnet", "--claude-model", help="Claude model: sonnet, opus, haiku, or full ID"
+    ),
+    max_iterations: int = typer.Option(
+        100, "--max-iterations", help="Max agent loop iterations"
+    ),
+    profiles: Optional[list[str]] = typer.Option(
+        None, "--profiles", help="Benchmark profiles (default: balanced)"
+    ),
+    ssh_user: str = typer.Option("root", "--ssh-user", help="SSH user for vLLM host"),
+    output: str = typer.Option(
+        "agent_reports", "--output", "-o", help="Output directory for reports"
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
+    oc_mode: bool = typer.Option(False, "--oc-mode", help="Use oc exec instead of SSH"),
+    oc_namespace: Optional[str] = typer.Option(
+        None, "--oc-namespace", help="OpenShift namespace (required with --oc-mode)"
+    ),
+    oc_pod: Optional[str] = typer.Option(
+        None, "--oc-pod", help="Baseline pod name (required with --oc-mode)"
+    ),
+    kubeconfig: Optional[str] = typer.Option(
+        None, "--kubeconfig", help="Path to kubeconfig (default: $KUBECONFIG)"
+    ),
+    pod_template: Optional[str] = typer.Option(
+        None,
+        "--pod-template",
+        help="Pod YAML for experiment pods (examples/agent/experiment-pod.yaml)",
+    ),
+    vertex: bool = typer.Option(
+        False, "--vertex", help="Use Google Cloud Vertex AI for Claude"
+    ),
+    vertex_project_id: Optional[str] = typer.Option(
+        None, "--vertex-project-id", help="Vertex AI project ID"
+    ),
+    vertex_region: str = typer.Option(
+        "us-east5", "--vertex-region", help="Vertex AI region"
+    ),
+):
+    """Run the Claude-driven pod-per-experiment vLLM tuner.
+
+    The baseline pod/server is never restarted. Each experiment creates a
+    fresh pod (when --pod-template is set), benchmarks it with GuideLLM,
+    compares against baseline, then deletes it.
+    """
+    try:
+        from ..agent.main import run_agent
+    except ImportError as exc:
+        console.print(
+            "[red]Agent extras are not installed.[/red] "
+            "Install with: [bold]pip install -e '.[agent]'[/bold]"
+        )
+        console.print(f"[dim]{exc}[/dim]")
+        raise typer.Exit(1) from exc
+
+    args = Namespace(
+        vllm_endpoint=vllm_endpoint,
+        vllm_host=vllm_host,
+        model=model,
+        api_key=api_key or os.environ.get("ANTHROPIC_API_KEY"),
+        claude_model=claude_model,
+        max_iterations=max_iterations,
+        profiles=profiles or ["balanced"],
+        ssh_user=ssh_user,
+        output=output,
+        verbose=verbose,
+        oc_mode=oc_mode,
+        oc_namespace=oc_namespace,
+        oc_pod=oc_pod,
+        kubeconfig=kubeconfig or os.environ.get("KUBECONFIG"),
+        pod_template=pod_template,
+        vertex=vertex or os.environ.get("CLAUDE_CODE_USE_VERTEX", "0") == "1",
+        vertex_project_id=vertex_project_id
+        or os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID"),
+        vertex_region=vertex_region or os.environ.get("CLOUD_ML_REGION", "us-east5"),
+    )
+    run_agent(args)

--- a/auto_tune_vllm/cli/main.py
+++ b/auto_tune_vllm/cli/main.py
@@ -18,6 +18,7 @@ from ..core.storage.postgres_utils import clear_study_data, verify_database_conn
 from ..core.study_controller import StudyController
 from ..execution.backends import RayExecutionBackend
 from ..logging.manager import CentralizedLogger, LogStreamer
+from .agent_cmd import agent_command
 
 # Setup rich console and app
 console = Console()
@@ -26,6 +27,10 @@ app = typer.Typer(
     help="Distributed hyperparameter optimization for vLLM serving",
     add_completion=False,
 )
+app.command(
+    "agent",
+    help="Run the Claude-driven pod-per-experiment vLLM tuner",
+)(agent_command)
 
 # Setup logger for CLI
 logger = logging.getLogger(__name__)
@@ -1364,6 +1369,7 @@ def main():
         console.print("\nUse --help for available commands")
         console.print("\nQuick start:")
         console.print("  auto-tune-vllm optimize --config study.yaml")
+        console.print("  auto-tune-vllm agent --vllm-endpoint http://localhost:8000")
         console.print(
             "  auto-tune-vllm logs --study-name my_study --database-url postgresql://..."
         )

--- a/docs/agentic_tuning.md
+++ b/docs/agentic_tuning.md
@@ -1,0 +1,99 @@
+# Agentic vLLM Tuner
+
+Claude-driven alternative to Optuna search. The agent keeps a **read-only baseline**
+server, creates a **fresh pod per experiment**, benchmarks with GuideLLM, compares
+metrics with a 2% regression threshold, then deletes the experiment pod.
+
+This is complementary to `auto-tune-vllm optimize`: Optuna does Bayesian search over
+a declared parameter space; the agent reasons over logs, recipes, and results and
+chooses the next config itself.
+
+## Install
+
+```bash
+pip install -e ".[agent]"
+```
+
+Requires: `oc` (OpenShift mode) or SSH access, a running baseline vLLM server,
+and either `ANTHROPIC_API_KEY` or Vertex AI credentials.
+
+## OpenShift (recommended)
+
+1. Port-forward the **baseline** pod (never modified):
+
+```bash
+oc port-forward -n <namespace> <baseline-pod> 8000:8000
+```
+
+2. Copy and edit `examples/agent/experiment-pod.yaml` for your image, model path, PVC, and GPU count.
+
+3. Run:
+
+```bash
+auto-tune-vllm agent \
+    --vllm-endpoint http://localhost:8000 \
+    --model facebook/opt-125m \
+    --oc-mode \
+    --oc-pod <baseline-pod> \
+    --oc-namespace <namespace> \
+    --pod-template examples/agent/experiment-pod.yaml \
+    --max-iterations 30 \
+    --profiles balanced
+```
+
+## SSH mode
+
+```bash
+auto-tune-vllm agent \
+    --vllm-endpoint http://gpu-host:8000 \
+    --vllm-host gpu-host \
+    --ssh-user root \
+    --model meta-llama/Llama-3.1-8B \
+    --api-key "$ANTHROPIC_API_KEY"
+```
+
+## Vertex AI
+
+```bash
+export CLAUDE_CODE_USE_VERTEX=1
+export ANTHROPIC_VERTEX_PROJECT_ID=<project>
+export CLOUD_ML_REGION=us-east5
+
+auto-tune-vllm agent --vertex --vllm-endpoint http://localhost:8000 --model <model> ...
+```
+
+## What the agent does
+
+1. **Baseline** — `nvidia-smi`, launch args, GuideLLM `balanced` profile, parse vLLM logs.
+2. **Experiments** — `create_vllm_pod` with extra CLI args, benchmark, `compare_benchmarks`, `delete_vllm_pod`.
+3. **Stop** — 10 consecutive experiments with no >2% gain, or `--max-iterations`.
+4. **Report** — markdown + JSON under `agent_reports/`.
+
+The baseline pod is never killed or restarted. Experiment pods are cleaned up on exit (`atexit`).
+
+## Tools
+
+| Tool | Where it runs |
+|------|----------------|
+| `run_command` / `read_file` / `write_file` / `fetch_vllm_logs` | Remote (pod or SSH host) |
+| `run_benchmark` / `read_benchmark_results` / `compare_benchmarks` | Local (hits the port-forward) |
+| `create_vllm_pod` / `delete_vllm_pod` | OpenShift (`oc apply` / `oc delete`) |
+| `analyze_trace` / `map_kernel` / `check_preemptions` | Local analysis |
+
+## Profiles
+
+Defaults are conservative (tuned for small models like opt-125m). Edit
+`auto_tune_vllm/agent/settings.yaml` to raise ISL/OSL for production models.
+
+| Profile | ISL | OSL |
+|---------|-----|-----|
+| balanced | 128 | 128 |
+| decode_heavy | 128 | 512 |
+| prefill_heavy | 512 | 64 |
+| long_context | 1024 | 128 |
+
+## Origin
+
+Ported from the Team TOA hackathon agent
+([toa-vllm-hackathon](https://github.com/aas008/toa-vllm-hackathon)):
+pod-per-experiment architecture, GuideLLM harness, and 120+ vLLM log patterns.

--- a/examples/agent/README.md
+++ b/examples/agent/README.md
@@ -1,0 +1,14 @@
+# Agentic tuner examples
+
+See [docs/agentic_tuning.md](../docs/agentic_tuning.md) for the full guide.
+
+`experiment-pod.yaml` is the template cloned for each tuning attempt. The
+agent appends extra vLLM CLI args to the container `args` list, waits for
+readiness, port-forwards, benchmarks, then deletes the pod.
+
+Edit before use:
+
+- container image
+- `--model` path (must match what is on the PVC)
+- `claimName` for model storage
+- GPU request/limit

--- a/examples/agent/experiment-pod.yaml
+++ b/examples/agent/experiment-pod.yaml
@@ -1,0 +1,57 @@
+# Template pod for agentic pod-per-experiment tuning.
+# The baseline pod is never modified. Each experiment clones this template,
+# appends extra vLLM CLI args, benchmarks it, then deletes it.
+#
+# Usage:
+#   auto-tune-vllm agent \
+#     --vllm-endpoint http://localhost:8000 \
+#     --model facebook/opt-125m \
+#     --oc-mode --oc-pod <baseline-pod> --oc-namespace <ns> \
+#     --pod-template examples/agent/experiment-pod.yaml
+#
+# Edit image, model path, PVC, and GPU count for your cluster before running.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vllm-tune-experiment
+  labels:
+    app: auto-tune-vllm
+    vllm-experiment: "true"
+spec:
+  containers:
+    - name: vllm
+      image: vllm/vllm-openai:v0.11.0
+      args:
+        - --model
+        - /models/facebook/opt-125m
+        - --port
+        - "8000"
+        - --dtype
+        - auto
+      env:
+        - name: HF_HOME
+          value: /tmp/hf-cache
+      ports:
+        - containerPort: 8000
+          name: http
+      resources:
+        requests:
+          cpu: "2"
+          memory: 8Gi
+          nvidia.com/gpu: "1"
+        limits:
+          nvidia.com/gpu: "1"
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 8000
+        initialDelaySeconds: 30
+        periodSeconds: 5
+      volumeMounts:
+        - name: model-storage
+          mountPath: /models
+  volumes:
+    - name: model-storage
+      persistentVolumeClaim:
+        claimName: model-pvc
+  restartPolicy: Never

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,14 @@ viz = [
     "plotly>=5.0.0",
     "pandas>=2.0.0",
 ]
+# Claude-driven agentic tuner (pod-per-experiment)
+agent = [
+    "anthropic[vertex]>=0.40.0",
+    "paramiko>=3.0",
+    "pandas>=2.0",
+    "numpy>=1.24",
+    "guidellm>=0.1.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/openshift-psap/auto-tuning-vllm"
@@ -72,6 +80,9 @@ target-version = "py310"
 select = ["E", "F", "I"]
 ignore = []
 
+[tool.ruff.lint.per-file-ignores]
+"auto_tune_vllm/agent/**" = ["E501"]
+
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
@@ -81,3 +92,7 @@ pythonVersion = "3.10"
 typeCheckingMode = "recommended"
 reportUnusedVariable = true
 reportUnusedImport = true
+exclude = [
+    "**/__pycache__",
+    "auto_tune_vllm/agent",
+]


### PR DESCRIPTION
Port the TOA hackathon agent into auto-tune-vllm as `auto-tune-vllm agent`, without changing the Optuna optimizer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Claude-driven vLLM tuning agent with automated benchmarking, profiling, analysis, and optimization workflows.
  * Added support for SSH and OpenShift execution, including isolated experiment pods.
  * Added trace analysis, kernel mapping, regression detection, cost-efficiency analysis, and vLLM log parsing.
  * Added Markdown and JSON tuning reports with performance, cost, profiling, and usage summaries.
  * Added a new `agent` CLI command and configurable workload profiles.

* **Documentation**
  * Added setup, usage, configuration, and experiment-pod guidance for the agentic tuner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->